### PR TITLE
Butterfly display, updated masses for TMT-16, misc UI enhancements, Unix line-endings

### DIFF
--- a/js/peptide.js
+++ b/js/peptide.js
@@ -6,15 +6,15 @@
 // Peptide sequence and modifications
 // -----------------------------------------------------------------------------
 function Peptide(seq, staticModifications, varModifications, ntermModification, ctermModification, maxNeutralLossCount) {
-	
-	var sequence = seq;
+
+    var sequence = seq;
     if(!sequence) {
         sequence = "";
     }
 
-	var ntermMod = ntermModification;
-	var ctermMod = ctermModification;
-	var staticMods = [];
+    var ntermMod = ntermModification;
+    var ctermMod = ctermModification;
+    var staticMods = [];
     var varMods = [];
     var potentialLosses_custom = {};
     var potentialLosses_lorikeet = {};
@@ -99,10 +99,10 @@ function Peptide(seq, staticModifications, varModifications, ntermModification, 
             // add N-terminal H
             mass = mass + Ion.MASS_H;
             // add C-terminal OH
-            mass = mass + Ion.MASS_O + Ion.MASS_H;
+        mass = mass + Ion.MASS_O + Ion.MASS_H;
 
-            return mass;
-        }
+        return mass;
+    }
 
     this.getPotentialLosses = function _getPotentialLosses(sion)
     {
@@ -496,15 +496,15 @@ function Peptide(seq, staticModifications, varModifications, ntermModification, 
 // Modification
 //-----------------------------------------------------------------------------
 function Modification(aminoAcid, mass, losses) {
-	this.aa = aminoAcid;
-	this.modMass = mass;
+    this.aa = aminoAcid;
+    this.modMass = mass;
     this.losses = losses;
 }
 
 function VariableModification(pos, mass, aminoAcid, losses) {
-	this.position = parseInt(pos);
-	this.aa = aminoAcid;
-	this.modMass = mass;
+    this.position = parseInt(pos);
+    this.aa = aminoAcid;
+    this.modMass = mass;
     this.losses = losses;
 }
 //-----------------------------------------------------------------------------

--- a/js/specview.js
+++ b/js/specview.js
@@ -5,7 +5,7 @@
 (function($) {
 
     // plugin name - specview
-	$.fn.specview = function (opts) {
+    $.fn.specview = function (opts) {
 
         var defaults = {
                 sequence: null,
@@ -35,6 +35,7 @@
                 sparsePeaks: null,
                 ms1peaks: null,
                 ms1scanLabel: null,
+                ms2peaks2Label: '',
                 precursorPeaks: null,
                 precursorPeakClickFn: null,
                 zoomMs1: false,
@@ -51,17 +52,17 @@
                 labelImmoniumIons: true,
                 labelPrecursorPeak: true,
                 labelReporters: false,
-				tooltipZIndex: null,
+	        tooltipZIndex: null,
                 showMassErrorPlot: false,
                 massErrorPlotDefaultUnit: null,
-                userReporterIons: null,
-                // Use these option to set the x-axis range (m/z) that will be displayed when the MS/MS plot is initialized or is fully zoomed out.
+	        userReporterIons: null,
+                // Use these options to set the x-axis range (m/z) that will be displayed when the MS/MS plot is initialized or is fully zoomed out.
                 // Default range is the min and max peak m/z.
                 minDisplayMz: null,
-	            maxDisplayMz: null
+	        maxDisplayMz: null
         };
-			
-	    var options = $.extend(true, {}, defaults, opts); // this is a deep copy
+
+	var options = $.extend(true, {}, defaults, opts); // this is a deep copy
 
         return this.each(function() {
 
@@ -69,7 +70,7 @@
             init($(this), options);
 
         });
-	};
+    };
 
     var index = 0;
     var massErrorTypeTh = 'Th';		// Th are units of m/z
@@ -112,12 +113,13 @@
             fileinfo: "fileinfo",
             seqinfo: "seqinfo",
             peakDetect: "peakDetect",
-	        labelPrecursor: "labelPrecursor",
+	    labelPrecursor: "labelPrecursor",
             immoniumIons: "immoniumIons",
-	        reporterIons: "reporterIons",
-            anticInfo: "anticInfo",
-            userReporterIons: "userReporterIons"
-	};
+	    reporterIons: "reporterIons",
+	    showIonTable: "showIonTable",
+	    anticInfo: "anticInfo",
+	    userReporterIons: "userReporterIons"
+    };
 
     function getElementId(container, elementId){
         return elementId+"_"+container.data("index");
@@ -159,7 +161,7 @@
         options.variableMods = parsedVarMods;
 
         var peptide = new Peptide(options.sequence, options.staticMods, options.variableMods,
-                                options.ntermMod, options.ctermMod, options.maxNeutralLossCount);
+                                  options.ntermMod, options.ctermMod, options.maxNeutralLossCount);
         options.peptide = peptide;
 
         // Calculate a theoretical m/z from the given sequence and charge
@@ -201,7 +203,7 @@
             showSequenceInfo(container, options);
             showFileInfo(container, options);
             showModInfo(container, options);
-            showUserReporterIonsInfo(container, options);
+	    showUserReporterIonsInfo(container, options);
         }
 
         // calculate precursor ions
@@ -213,7 +215,7 @@
         // Calculate reporter ion labels, if required
         calculateReporterIons(container);
 
-        // calculate user-supplied reporter ions
+	// calculate user-supplied reporter ions
         if(options.userReporterIons) {
             calculateUserReporters(options, container);
         }
@@ -297,22 +299,22 @@
         {
             userDefined = true;
             defaultSelected['a'] = options.showA;
-           }
+        }
         if(options.showB.length > 0)
         {
             userDefined = true;
             defaultSelected['b'] = options.showB;
-         }
+        }
         if(options.showC.length > 0)
         {
             userDefined = true;
             defaultSelected['c'] = options.showC;
-       }
+	}
         if(options.showX.length > 0)
         {
             userDefined = true;
             defaultSelected['x'] = options.showX;
-    }
+	}
         if(options.showY.length > 0)
         {
             userDefined = true;
@@ -378,124 +380,171 @@
         container.data("anticPrecursor", 0); // total annotated ion current: precursor peak
         container.data("anticImmonium", 0); // total annotated ion current: immonium ions
         container.data("anticReporter", 0); // total annotated ion current: reporter ions
+        container.data("totalIonCurrent", getTotalIonCurrent(options.peaks)); // total ion current
 
+        var maxInt = getMaxInt(options.peaks);
+        var maxIntUp = maxInt;      //get max peaks value in up peak list
+        var maxIntDown = 0;         //for 2nd "butterfly" spectrum
+        if(options.peaks2){
+            maxIntDown = getMaxInt(options.peaks2);   //get max peaks value in down peak list
+        }
 
-        var maxInt = getMaxInt(options);
-        var __xrange = getPlotXRange(options);
+	var __xrange = getPlotXRange(options);
+
 
         var plotOptions =  {
-                series: {
-                    peaks: { show: true, lineWidth: 1, shadowSize: 0},
-                    shadowSize: 0
-                },
-                selection: { mode: "x", color: "#F0E68C" },
-                grid: { show: true,
-                        hoverable: true,
-                        clickable: false,
-                        autoHighlight: false,
-                        borderWidth: 1,
-                        labelMargin: 1},
-                xaxis: { tickLength: 3, tickColor: "#000",
-                         min: __xrange.xmin,
-                         max: __xrange.xmax},
-                yaxis: { tickLength: 0, tickColor: "#000",
-                         max: maxInt*1.1,
-                         ticks: [0, maxInt*0.1, maxInt*0.2, maxInt*0.3, maxInt*0.4, maxInt*0.5,
-                                 maxInt*0.6, maxInt*0.7, maxInt*0.8, maxInt*0.9, maxInt],
-                         tickFormatter: function(val, axis) {return Math.round((val * 100)/maxInt)+"%";}}
-	        }
+            series: {
+                peaks: { show: true, lineWidth: 1, shadowSize: 0},
+                shadowSize: 0
+            },
+            selection: { mode: "x", color: "#F0E68C" },
+            grid: { show: true,
+                    hoverable: true,
+                    clickable: false,
+                    autoHighlight: false,
+                    borderWidth: 1,
+                    labelMargin: 1},
+            xaxis: { tickLength: 3, tickColor: "#000",
+                     min: __xrange.xmin,
+                     max: __xrange.xmax},
+	}
+
+        var yaxis = { tickLength: 0, tickColor: "#000",
+		  max: maxInt*1.1,
+		  ticks: [0, maxInt*0.1, maxInt*0.2, maxInt*0.3, maxInt*0.4, maxInt*0.5,
+			  maxInt*0.6, maxInt*0.7, maxInt*0.8, maxInt*0.9, maxInt],
+		  tickFormatter: function(val, axis) {return Math.round((val * 100)/maxInt)+"%";}
+		}
+
+        var yaxes = [
+            { tickLength: 0, tickColor: "#000",
+              max: maxIntUp*1.1,
+              min: maxIntUp*-1.1,
+              ticks: [0, maxIntUp*0.1, maxIntUp*0.2, maxIntUp*0.3, maxIntUp*0.4, maxIntUp*0.5,
+                      maxIntUp*0.6, maxIntUp*0.7, maxIntUp*0.8, maxIntUp*0.9, maxIntUp],
+              tickFormatter: function(val, axis) {return Math.round((val * 100)/maxIntUp)+"%";}
+            },
+            { tickLength: 0, tickColor: "#000",
+              min: maxIntDown*-1.1,
+              max: maxIntDown*1.1,
+              position:"bottom",
+              ticks: [0, maxIntDown*0.1, maxIntDown*0.2, maxIntDown*0.3, maxIntDown*0.4, maxIntDown*0.5,
+                      maxIntDown*0.6, maxIntDown*0.7, maxIntDown*0.8, maxIntDown*0.9, maxIntDown],
+              tickFormatter: function(val, axis) {return Math.round((val * 100)/maxIntDown)+"%";},
+              transform: function (v) { return -v; },
+            }
+        ]
+
+        //added double yaxis for butterfly comparing:
+        if (maxIntDown > 0) {
+            plotOptions['yaxes'] =  yaxes;
+            plotOptions.grid.markings = [{yaxis:{from:0, to:0}, color:"#555555", lineWidth:0.5}];
+            plotOptions['legend'] = {position: "se"};
+	}
+        else {
+            plotOptions['yaxis'] =  yaxis;
+	}
+
         container.data("plotOptions", plotOptions);
         container.data("maxInt", maxInt);
-
     }
 
-	function getMaxInt(options) {
-		var maxInt = 0;
-		for(var j = 0; j < options.peaks.length; j += 1) {
-			var peak = options.peaks[j];
-			if(peak[1] > maxInt) {
-				maxInt = peak[1];
-			}
-		}
-		//alert(maxInt);
-		return maxInt;
+    // total ion current = sum all peak intensities
+    function getTotalIonCurrent(peaks) {
+        var totCurrent = 0;
+        for(var peak of peaks)
+            totCurrent += peak[1];
+        //console.log("Ion Current: "+totCurrent);
+        return totCurrent;
+    }
+
+    // extract max from peak list
+    function getMaxInt(peaks) {
+	var maxInt = 0;
+	for(var peak of peaks) {
+	    if(peak[1] > maxInt) {
+		maxInt = peak[1];
+	    }
 	}
-	
-	function round(number) {
-		return number.toFixed(4);
-	}
-	
-	function setMassError(container) {
+	//alert(maxInt);
+	return maxInt;
+    }
+
+    function round(number) {
+	return number.toFixed(4);
+    }
+
+    function setMassError(container) {
         var options = container.data("options");
-   		var me = parseFloat($(getElementSelector(container, elementIds.massError)).val());
-        var unit = getMassErrorUnit(container);
-		if(me !== options.massError) {
-            options.massError = me;
-			container.data("massErrorChanged", true);
-		}
-        else if(options.massErrorUnit !== unit)
-        {
-            options.massErrorUnit = unit;
-            container.data("massErrorChanged", true);
-        }
-		else {
-			container.data("massErrorChanged", false);
-		}
-   	}
+	var me = parseFloat($(getElementSelector(container, elementIds.massError)).val());
+	var unit = getMassErrorUnit(container);
+	if(me !== options.massError) {
+	    options.massError = me;
+	    container.data("massErrorChanged", true);
+	}
+	else if(options.massErrorUnit !== unit)
+	{
+	    options.massErrorUnit = unit;
+	    container.data("massErrorChanged", true);
+	}
+	else {
+	    container.data("massErrorChanged", false);
+	}
+    }
 
     // -----------------------------------------------
-	// CREATE MS1 PLOT
-	// -----------------------------------------------
-	function createMs1Plot(container) {
+    // CREATE MS1 PLOT
+    // -----------------------------------------------
+    function createMs1Plot(container) {
 
         var ms1zoomRange = container.data("ms1zoomRange");
         var options = container.data("options");
 
-		var data = [{data: options.ms1peaks, color: "#bbbbbb", labelType: 'none', hoverable: false, clickable: false}];
-		if(options.precursorPeaks) {
-			if(options.precursorPeakClickFn)
-				data.push({data: options.precursorPeaks, color: "#ff0000", hoverable: true, clickable: true});
-			else
-				data.push({data: options.precursorPeaks, color: "#ff0000", hoverable: false, clickable: false});
-		}
-		
-		// the MS/MS plot should have been created by now.  This is a hack to get the plots aligned.
-		// We will set the y-axis labelWidth to this value.
-		var labelWidth = container.data("plot").getAxes().yaxis.labelWidth;
+	var data = [{data: options.ms1peaks, color: "#bbbbbb", labelType: 'none', hoverable: false, clickable: false}];
+	if(options.precursorPeaks) {
+	    if(options.precursorPeakClickFn)
+		data.push({data: options.precursorPeaks, color: "#ff0000", hoverable: true, clickable: true});
+	    else
+		data.push({data: options.precursorPeaks, color: "#ff0000", hoverable: false, clickable: false});
+	}
+
+	// the MS/MS plot should have been created by now.  This is a hack to get the plots aligned.
+	// We will set the y-axis labelWidth to this value.
+	var labelWidth = container.data("plot").getAxes().yaxis.labelWidth;
 
         var precursorSelectionWin = [];
         if(options.selWinLow && options.selWinHigh)
         {
             precursorSelectionWin = [{ color:"#ccd8e2", xaxis:{from:options.selWinLow, to:options.selWinHigh}, }];
         }
-		var ms1plotOptions = {
-				series: { peaks: {show: true, shadowSize: 0}, shadowSize: 0},
-				grid: { show: true, 
-						hoverable: true, 
-						autoHighlight: true,
-						clickable: true,
-                        markings: precursorSelectionWin,
-						borderWidth: 1,
-						labelMargin: 1},
-				selection: { mode: "xy", color: "#F0E68C" },
-		        xaxis: { tickLength: 2, tickColor: "#000" },
-		    	yaxis: { tickLength: 0, tickColor: "#fff", ticks: [], labelWidth: labelWidth }
-		};
-		
-		if(ms1zoomRange) {
-			ms1plotOptions.xaxis.min = ms1zoomRange.xaxis.from;
-			ms1plotOptions.xaxis.max = ms1zoomRange.xaxis.to;
-			ms1plotOptions.yaxis.min = 0; // ms1zoomRange.yaxis.from;
-			ms1plotOptions.yaxis.max = ms1zoomRange.yaxis.to;
-		}
+	var ms1plotOptions = {
+	    series: { peaks: {show: true, shadowSize: 0}, shadowSize: 0},
+	    grid: { show: true,
+		    hoverable: true,
+		    autoHighlight: true,
+		    clickable: true,
+                    markings: precursorSelectionWin,
+		    borderWidth: 1,
+		    labelMargin: 1},
+	    selection: { mode: "xy", color: "#F0E68C" },
+	    xaxis: { tickLength: 2, tickColor: "#000" },
+	    yaxis: { tickLength: 0, tickColor: "#fff", ticks: [], labelWidth: labelWidth }
+	};
 
-		var placeholder = $(getElementSelector(container, elementIds.msPlot));
-		var ms1plot = $.plot(placeholder, data, ms1plotOptions);
+	if(ms1zoomRange) {
+	    ms1plotOptions.xaxis.min = ms1zoomRange.xaxis.from;
+	    ms1plotOptions.xaxis.max = ms1zoomRange.xaxis.to;
+	    ms1plotOptions.yaxis.min = 0; // ms1zoomRange.yaxis.from;
+	    ms1plotOptions.yaxis.max = ms1zoomRange.yaxis.to;
+	}
+
+	var placeholder = $(getElementSelector(container, elementIds.msPlot));
+	var ms1plot = $.plot(placeholder, data, ms1plotOptions);
         container.data("ms1plot", ms1plot);
 
 
-		// Mark the precursor peak with a green triangle.
-		if(options.precursorMz) {
+	// Mark the precursor peak with a green triangle.
+	if(options.precursorMz) {
 
             var o = ms1plot.pointOffset({ x: options.precursorMz, y: options.precursorIntensity});
             var ctx = ms1plot.getCanvas().getContext("2d");
@@ -508,108 +557,108 @@
             ctx.fill();
             placeholder.append('<div style="position:absolute;left:' + (o.left + 4) + 'px;top:' + (o.top-4) + 'px;color:#000;font-size:smaller">'+options.precursorMz.toFixed(2)+'</div>');
 
-		}
-		
-		// mark the scan number if we have it
-		o = ms1plot.getPlotOffset();
-		if(options.ms1scanLabel) {
-			placeholder.append('<div style="position:absolute;left:' + (o.left + 4) + 'px;top:' + (o.top+4) + 'px;color:#666;font-size:smaller">MS1 scan: '+options.ms1scanLabel+'</div>');
-		}
-		
-		// zoom out icon on plot right hand corner if we are not already zoomed in to the precursor.
-		if(container.data("ms1zoomRange")) {
-			placeholder.append('<div id="'+getElementId(container, elementIds.ms1plot_zoom_out)+'" class="zoom_out_link"  style="position:absolute; left:'
-					+ (o.left + ms1plot.width() - 40) + 'px;top:' + (o.top+4) + 'px;"></div>');
+	}
 
-			$(getElementSelector(container, elementIds.ms1plot_zoom_out)).click( function() {
-				container.data("ms1zoomRange", null);
-				createMs1Plot(container);
-			});
-		}
-		else {
-			placeholder.append('<div id="'+getElementId(container, elementIds.ms1plot_zoom_in)+'" class="zoom_in_link"  style="position:absolute; left:'
-					+ (o.left + ms1plot.width() - 20) + 'px;top:' + (o.top+4) + 'px;"></div>');
-			$(getElementSelector(container, elementIds.ms1plot_zoom_in)).click( function() {
-				var ranges = {};
-				ranges.yaxis = {};
-				ranges.xaxis = {};
-				ranges.yaxis.from = 0.0;
-				ranges.yaxis.to = options.maxIntensityInMs1ZoomRange;
+	// mark the scan number if we have it
+	o = ms1plot.getPlotOffset();
+	if(options.ms1scanLabel) {
+	    placeholder.append('<div style="position:absolute;left:' + (o.left + 4) + 'px;top:' + (o.top+4) + 'px;color:#666;font-size:smaller">MS1 scan: '+options.ms1scanLabel+'</div>');
+	}
+
+	// zoom out icon on plot right hand corner if we are not already zoomed in to the precursor.
+	if(container.data("ms1zoomRange")) {
+	    placeholder.append('<div id="'+getElementId(container, elementIds.ms1plot_zoom_out)+'" class="zoom_out_link"  style="position:absolute; left:'
+			       + (o.left + ms1plot.width() - 40) + 'px;top:' + (o.top+4) + 'px;"></div>');
+
+	    $(getElementSelector(container, elementIds.ms1plot_zoom_out)).click( function() {
+		container.data("ms1zoomRange", null);
+		createMs1Plot(container);
+	    });
+	}
+	else {
+	    placeholder.append('<div id="'+getElementId(container, elementIds.ms1plot_zoom_in)+'" class="zoom_in_link"  style="position:absolute; left:'
+			       + (o.left + ms1plot.width() - 20) + 'px;top:' + (o.top+4) + 'px;"></div>');
+	    $(getElementSelector(container, elementIds.ms1plot_zoom_in)).click( function() {
+		var ranges = {};
+		ranges.yaxis = {};
+		ranges.xaxis = {};
+		ranges.yaxis.from = 0.0;
+		ranges.yaxis.to = options.maxIntensityInMs1ZoomRange;
 
                 ranges.xaxis.from = options.precursorMz - 5.0;
                 ranges.xaxis.to = options.precursorMz + 5.0;
 
                 container.data("ms1zoomRange", ranges);
-				createMs1Plot(container);
-			});
-		}
+		createMs1Plot(container);
+	    });
 	}
+    }
 
     // -----------------------------------------------
-	// SET UP INTERACTIVE ACTIONS FOR MS1 PLOT
-	// -----------------------------------------------
-	function setupMs1PlotInteractions(container) {
-		
-		var placeholder = $(getElementSelector(container, elementIds.msPlot));
+    // SET UP INTERACTIVE ACTIONS FOR MS1 PLOT
+    // -----------------------------------------------
+    function setupMs1PlotInteractions(container) {
+
+	var placeholder = $(getElementSelector(container, elementIds.msPlot));
         var options = container.data("options");
 
-		// allow clicking on plot if we have a function to handle the click
-		if(options.precursorPeakClickFn != null) {
-			placeholder.bind("plotclick", function (event, pos, item) {
-				
-		        if (item) {
-		          //highlight(item.series, item.datapoint);
-		        	options.precursorPeakClickFn(item.datapoint[0]);
-		        }
-		    });
+	// allow clicking on plot if we have a function to handle the click
+	if(options.precursorPeakClickFn != null) {
+	    placeholder.bind("plotclick", function (event, pos, item) {
+
+		if (item) {
+		    //highlight(item.series, item.datapoint);
+		    options.precursorPeakClickFn(item.datapoint[0]);
 		}
-		
-		// allow zooming the plot
-		placeholder.bind("plotselected", function (event, ranges) {
-            container.data("ms1zoomRange", ranges);
-			createMs1Plot(container);
 	    });
-		
 	}
 
-    // -----------------------------------------------
-	// CREATE MS/MS PLOT
-	// -----------------------------------------------
-	function createPlot(container, datasets) {
+	// allow zooming the plot
+	placeholder.bind("plotselected", function (event, ranges) {
+            container.data("ms1zoomRange", ranges);
+	    createMs1Plot(container);
+	});
 
-        var plot;
-    	if(!container.data("zoomRange"))
+    }
+
+    // -----------------------------------------------
+    // CREATE MS/MS PLOT
+    // -----------------------------------------------
+    function createPlot(container, datasets) {
+
+	var plot;
+	if(!container.data("zoomRange"))
         {
             plot = $.plot($(getElementSelector(container, elementIds.msmsplot)), datasets,  container.data("plotOptions"));
         }
-    	else {
+	else {
             var zoomRange = container.data("zoomRange");
             var selectOpts = {};
-    		if($(getElementSelector(container, elementIds.zoom_x)).is(":checked"))
-    			selectOpts.xaxis = { min: zoomRange.xaxis.from, max: zoomRange.xaxis.to };
-    		if($(getElementSelector(container, elementIds.zoom_y)).is(":checked"))
-    			selectOpts.yaxis = { min: 0, max: zoomRange.yaxis.to };
-    		
-    		plot = $.plot(getElementSelector(container, elementIds.msmsplot), datasets,
-                      $.extend(true, {}, container.data("plotOptions"), selectOpts));
+	    if($(getElementSelector(container, elementIds.zoom_x)).is(":checked"))
+		selectOpts.xaxis = { min: zoomRange.xaxis.from, max: zoomRange.xaxis.to };
+	    if($(getElementSelector(container, elementIds.zoom_y)).is(":checked"))
+		selectOpts.yaxis = { min: 0, max: zoomRange.yaxis.to };
 
-    		// zoom out icon on plot right hand corner
-    		var o = plot.getPlotOffset();
-    		$(getElementSelector(container, elementIds.msmsplot)).append('<div id="'+getElementId(container, elementIds.ms2plot_zoom_out)+'" class="zoom_out_link" style="position:absolute; left:'
-					+ (o.left + plot.width() - 20) + 'px;top:' + (o.top+4) + 'px"></div>');
+	    plot = $.plot(getElementSelector(container, elementIds.msmsplot), datasets,
+			  $.extend(true, {}, container.data("plotOptions"), selectOpts));
 
-			$(getElementSelector(container, elementIds.ms2plot_zoom_out)).click( function() {
+	    // zoom out icon on plot right hand corner
+	    var o = plot.getPlotOffset();
+	    $(getElementSelector(container, elementIds.msmsplot)).append('<div id="'+getElementId(container, elementIds.ms2plot_zoom_out)+'" class="zoom_out_link" style="position:absolute; left:'
+									 + (o.left + plot.width() - 20) + 'px;top:' + (o.top+4) + 'px"></div>');
+
+	    $(getElementSelector(container, elementIds.ms2plot_zoom_out)).click( function() {
                 resetZoom(container);
-			});
-    	}
+	    });
+	}
 
-    	// we have re-calculated and re-drawn everything..
-    	container.data("massTypeChanged", false);
-    	container.data("massErrorChanged",false);
-    	container.data("peakAssignmentTypeChanged", false);
-    	container.data("peakLabelTypeChanged", false);
-    	container.data("selectedNeutralLossChanged", false);
-        container.data("plot", plot);
+	// we have re-calculated and re-drawn everything..
+	container.data("massTypeChanged", false);
+	container.data("massErrorChanged",false);
+	container.data("peakAssignmentTypeChanged", false);
+	container.data("peakLabelTypeChanged", false);
+	container.data("selectedNeutralLossChanged", false);
+	container.data("plot", plot);
 
         // Draw the peak mass error plot
         plotPeakMassErrorPlot(container, datasets);
@@ -683,23 +732,23 @@
         var massErrorPlotOptions = {
             series:{data:data, points:{show:true, fill:true, radius:1}, shadowSize:0},
             grid:{ show:true,
-                hoverable:true,
-                autoHighlight:false,
-                clickable:false,
-                borderWidth:1,
-                labelMargin:1,
-                markings:[
-                    {yaxis:{from:0, to:0}, color:"#555555", lineWidth:0.5}
-                ]  // draw a horizontal line at y=0
-            },
+                   hoverable:true,
+                   autoHighlight:false,
+                   clickable:false,
+                   borderWidth:1,
+                   labelMargin:1,
+                   markings:[
+                       {yaxis:{from:0, to:0}, color:"#555555", lineWidth:0.5}
+                   ]  // draw a horizontal line at y=0
+		 },
             selection:{ mode:"xy", color:"#F0E68C" },
             xaxis:{ tickLength:3, tickColor:"#000",
-                min:__xrange.xmin,
-                max:__xrange.xmax},
+                    min:__xrange.xmin,
+                    max:__xrange.xmax},
             yaxis:{ tickLength:0, tickColor:"#fff",
-                min:minMassError - ypadding,
-                max:maxMassError + ypadding,
-                labelWidth:labelWidth }
+                    min:minMassError - ypadding,
+                    max:maxMassError + ypadding,
+                    labelWidth:labelWidth }
         };
 
 
@@ -713,10 +762,10 @@
         // Display clickable mass error unit.
         var o = massErrorPlot.getPlotOffset();
         placeholder.append('<div id="' + getElementId(container, elementIds.massErrorPlot_unit) + '" class="link"  '
-            + 'style="position:absolute; left:'
-            + (o.left + 5) + 'px;top:' + (o.top + 4) + 'px;'
-            + 'background-color:yellow; font-style:italic">'
-            + options.massErrorPlotDefaultUnit + '</div>');
+			   + 'style="position:absolute; left:'
+			   + (o.left + 5) + 'px;top:' + (o.top + 4) + 'px;'
+			   + 'background-color:yellow; font-style:italic">'
+			   + options.massErrorPlotDefaultUnit + '</div>');
         // Toggle mass error unit on click.
         $(getElementSelector(container, elementIds.massErrorPlot_unit)).click(function () {
             var unit = $(this).text();
@@ -742,10 +791,10 @@
 
                     $(getElementSelector(container, elementIds.msmstooltip)).remove();
                     var x = item.datapoint[0].toFixed(2),
-                        y = item.datapoint[1].toFixed(2);
+                    y = item.datapoint[1].toFixed(2);
 
                     showTooltip(container, item.pageX, item.pageY,
-                        tooltip_xlabel + ": " + x + "<br>" + tooltip_ylabel + ": " + y, options);
+				tooltip_xlabel + ": " + x + "<br>" + tooltip_ylabel + ": " + y, options);
                 }
             }
             else {
@@ -754,175 +803,172 @@
             }
         }
     }
-	
-	// -----------------------------------------------
-	// SET UP INTERACTIVE ACTIONS FOR MS/MS PLOT
-	// -----------------------------------------------
-	function setupInteractions (container, options) {
 
-		// ZOOMING
-	    $(getElementSelector(container, elementIds.msmsplot)).bind("plotselected", function (event, ranges) {
-	    	container.data("zoomRange", ranges);
-	    	createPlot(container, getDatasets(container));
-	    });
-	    
-	    // ZOOM AXES
-	    $(getElementSelector(container, elementIds.zoom_x)).click(function() {
-	    	resetAxisZoom(container);
-	    });
-	    $(getElementSelector(container, elementIds.zoom_y)).click(function() {
-	    	resetAxisZoom(container);
-	    });
-	    
-		// RESET ZOOM
-		$(getElementSelector(container, elementIds.resetZoom)).click(function() {
-			resetZoom(container);
-	   	});
-		
-		// UPDATE
-		$(getElementSelector(container, elementIds.update)).click(function() {
-			container.data("zoomRange", null); // zoom out fully
-			setMassError(container);
-            plotAccordingToChoices(container);
-	   	});
-		
-		// TOOLTIPS
-		$(getElementSelector(container, elementIds.msmsplot)).bind("plothover", function (event, pos, item) {
+    // -----------------------------------------------
+    // SET UP INTERACTIVE ACTIONS FOR MS/MS PLOT
+    // -----------------------------------------------
+    function setupInteractions (container, options) {
 
-            displayTooltip(item, container, options, "m/z", "intensity");
-	    });
-		$(getElementSelector(container, elementIds.enableTooltip)).click(function() {
-			$(getElementSelector(container, elementIds.msmstooltip)).remove();
-		});
+	// ZOOMING
+	$(getElementSelector(container, elementIds.msmsplot)).bind("plotselected", function (event, ranges) {
+	    container.data("zoomRange", ranges);
+	    createPlot(container, getDatasets(container));
+	});
+
+	// ZOOM AXES
+	$(getElementSelector(container, elementIds.zoom_x)).click(function() {
+	    resetAxisZoom(container);
+	});
+	$(getElementSelector(container, elementIds.zoom_y)).click(function() {
+	    resetAxisZoom(container);
+	});
+
+	// RESET ZOOM
+	$(getElementSelector(container, elementIds.resetZoom)).click(function() {
+	    resetZoom(container);
+	});
+
+	// UPDATE
+	$(getElementSelector(container, elementIds.update)).click(function() {
+	    container.data("zoomRange", null); // zoom out fully
+	    setMassError(container);
+	    plotAccordingToChoices(container);
+	});
+
+	// TOOLTIPS
+	$(getElementSelector(container, elementIds.msmsplot)).bind("plothover", function (event, pos, item) {
+	    displayTooltip(item, container, options, "m/z", "intensity");
+	});
+	$(getElementSelector(container, elementIds.enableTooltip)).click(function() {
+	    $(getElementSelector(container, elementIds.msmstooltip)).remove();
+	});
 
         // PLOT MASS ERROR CHECKBOX
         $(getElementSelector(container, elementIds.massErrorPlot_option)).click(function() {
-            var plotDiv = $(getElementSelector(container, elementIds.massErrorPlot));
-            if($(this).is(':checked'))
-            {
+	    var plotDiv = $(getElementSelector(container, elementIds.massErrorPlot));
+	    if($(this).is(':checked'))
+	    {
                 plotDiv.show();
-            }
-            else
-            {
+	    }
+	    else
+	    {
                 plotDiv.hide();
-            }
+	    }
         });
 
-		
-		// SHOW / HIDE ION SERIES; UPDATE ON MASS TYPE CHANGE; 
-		// PEAK ASSIGNMENT TYPE CHANGED; PEAK LABEL TYPE CHANGED
-		var ionChoiceContainer = $(getElementSelector(container, elementIds.ion_choice));
-		ionChoiceContainer.find("input").click(function() {
-            plotAccordingToChoices(container);
+
+	// SHOW / HIDE ION SERIES; UPDATE ON MASS TYPE CHANGE;
+	// PEAK ASSIGNMENT TYPE CHANGED; PEAK LABEL TYPE CHANGED
+	var ionChoiceContainer = $(getElementSelector(container, elementIds.ion_choice));
+	ionChoiceContainer.find("input").click(function() {
+	    plotAccordingToChoices(container);
         });
 
         $(getElementSelector(container, elementIds.immoniumIons)).click(function() {
-            plotAccordingToChoices(container);
+	    plotAccordingToChoices(container);
         });
 
         $(getElementSelector(container, elementIds.reporterIons)).click(function() {
-            plotAccordingToChoices(container);
+	    plotAccordingToChoices(container);
         });
 
         $(getElementSelector(container, elementIds.labelPrecursor)).click(function() {
-		    plotAccordingToChoices(container);
-	    });
+	    plotAccordingToChoices(container);
+	});
 
-		// Plot neutral loss options
-		var neutralLossContainer = $(getElementSelector(container, elementIds.nl_choice));
-		neutralLossContainer.find("input").click(function() {
-			container.data("selectedNeutralLossChanged", true);
-            var selectedNeutralLosses = getNeutralLosses(container);
-            container.data("options").peptide.recalculateLossOptions(selectedNeutralLosses, container.data("options").maxNeutralLossCount);
-            plotAccordingToChoices(container);
-		});
+	// Plot neutral loss options
+	var neutralLossContainer = $(getElementSelector(container, elementIds.nl_choice));
+	neutralLossContainer.find("input").click(function() {
+	    container.data("selectedNeutralLossChanged", true);
+	    var selectedNeutralLosses = getNeutralLosses(container);
+	    container.data("options").peptide.recalculateLossOptions(selectedNeutralLosses, container.data("options").maxNeutralLossCount);
+	    plotAccordingToChoices(container);
+	});
 
         // Mass type options
-	    container.find("input[name='"+getRadioName(container, "massTypeOpt")+"']").click(function() {
-	    	container.data("massTypeChanged", true);
-	    	plotAccordingToChoices(container);
-	    });
+	container.find("input[name='"+getRadioName(container, "massTypeOpt")+"']").click(function() {
+	    container.data("massTypeChanged", true);
+	    plotAccordingToChoices(container);
+	});
 
         // Peak detect checkbox
         $(getElementSelector(container, elementIds.peakDetect)).click(function() {
-            container.data("peakAssignmentTypeChanged", true);
-            plotAccordingToChoices(container);
+	    container.data("peakAssignmentTypeChanged", true);
+	    plotAccordingToChoices(container);
         });
 
-	    container.find("input[name='"+getRadioName(container, "peakAssignOpt")+"']").click(function() {
-	    	container.data("peakAssignmentTypeChanged", true);
-	    	plotAccordingToChoices(container);
-	    });
+	container.find("input[name='"+getRadioName(container, "peakAssignOpt")+"']").click(function() {
+	    container.data("peakAssignmentTypeChanged", true);
+	    plotAccordingToChoices(container);
+	});
 
         $(getElementSelector(container, elementIds.deselectIonsLink)).click(function() {
-			ionChoiceContainer.find("input:checkbox:checked").each(function() {
-				$(this).attr('checked', "");
-			});
-			
-			plotAccordingToChoices(container);
-		});
-
-	    container.find("input[name='"+getRadioName(container, "peakLabelOpt")+"']").click(function() {
-	    	container.data("peakLabelTypeChanged", true);
-	    	plotAccordingToChoices(container);
+	    ionChoiceContainer.find("input:checkbox:checked").each(function() {
+		$(this).attr('checked', "");
 	    });
 
-	    
-	    
-	    // MOVING THE ION TABLE
-	    makeIonTableMovable(container, options);
-	    
-	    // CHANGING THE PLOT SIZE
-	    makePlotResizable(container);
-	    
-	    // PRINT SPECTRUM
-	    printPlot(container);
-		
-	}
-	
-	function resetZoom(container) {
-		container.data("zoomRange", null);
-		setMassError(container);
-		createPlot(container, getDatasets(container));
-	}
-	
-	function plotAccordingToChoices(container) {
+	    plotAccordingToChoices(container);
+	});
+
+	container.find("input[name='"+getRadioName(container, "peakLabelOpt")+"']").click(function() {
+	    container.data("peakLabelTypeChanged", true);
+	    plotAccordingToChoices(container);
+	});
+
+
+	// MOVING THE ION TABLE
+	makeIonTableMovable(container, options);
+
+	// CHANGING THE PLOT SIZE
+	makePlotResizable(container);
+
+	// PRINT SPECTRUM
+	printPlot(container);
+
+    }
+
+    function resetZoom(container) {
+	container.data("zoomRange", null);
+	setMassError(container);
+	createPlot(container, getDatasets(container));
+    }
+
+    function plotAccordingToChoices(container) {
         var data = getDatasets(container);
 
-		if (data.length > 0) {
+	if (data.length > 0) {
             createPlot(container, data);
             makeIonTable(container);
         }
     }
-	
-	function resetAxisZoom(container) {
+
+    function resetAxisZoom(container) {
 
         var plot = container.data("plot");
         var plotOptions = container.data("plotOptions");
 
-    	var zoom_x = false;
-		var zoom_y = false;
-		if($(getElementSelector(container, elementIds.zoom_x)).is(":checked"))
-			zoom_x = true;
-		if($(getElementSelector(container, elementIds.zoom_y)).is(":checked"))
-			zoom_y = true;
-    	if(zoom_x && zoom_y) {
-    		plotOptions.selection.mode = "xy";
-			if(plot) plot.getOptions().selection.mode = "xy";
-    	}
-		else if(zoom_x) {
-			plotOptions.selection.mode = "x";
-			if(plot) plot.getOptions().selection.mode = "x";
-		}
-		else if(zoom_y) {
-			plotOptions.selection.mode = "y";
-			if(plot) plot.getOptions().selection.mode = "y";
-		}
+	var zoom_x = false;
+	var zoom_y = false;
+	if($(getElementSelector(container, elementIds.zoom_x)).is(":checked"))
+	    zoom_x = true;
+	if($(getElementSelector(container, elementIds.zoom_y)).is(":checked"))
+	    zoom_y = true;
+	if(zoom_x && zoom_y) {
+	    plotOptions.selection.mode = "xy";
+	    if(plot) plot.getOptions().selection.mode = "xy";
 	}
-	
-	function showTooltip(container, x, y, contents, options) {
-	
-		var tooltipCSS = {
+	else if(zoom_x) {
+	    plotOptions.selection.mode = "x";
+	    if(plot) plot.getOptions().selection.mode = "x";
+	}
+	else if(zoom_y) {
+	    plotOptions.selection.mode = "y";
+	    if(plot) plot.getOptions().selection.mode = "y";
+	}
+    }
+
+    function showTooltip(container, x, y, contents, options) {
+	var tooltipCSS = {
             position: 'absolute',
             display: 'none',
             top: y + 5,
@@ -931,144 +977,148 @@
             padding: '2px',
             'background-color': '#F0E68C',
             opacity: 0.80 };
-			
-		if ( options.tooltipZIndex !== undefined && options.tooltipZIndex !== null ) {
-		
-			tooltipCSS["z-index"] = options.tooltipZIndex;
-		}
-	
+
+	if ( options.tooltipZIndex !== undefined && options.tooltipZIndex !== null ) {
+	    tooltipCSS["z-index"] = options.tooltipZIndex;
+	}
+
         $('<div id="'+getElementId(container, elementIds.msmstooltip)+'">' + contents + '</div>')
-				.css( tooltipCSS ).appendTo("body").fadeIn(200);
+	    .css( tooltipCSS ).appendTo("body").fadeIn(200);
     }
-	
-	function makePlotResizable(container) {
+
+    function makePlotResizable(container) {
 
         var options = container.data("options");
 
-		$(getElementSelector(container, elementIds.slider_width)).slider({
-			value:options.width,
-			min: 100,
-			max: 1500,
-			step: 50,
-			slide: function(event, ui) {
-				var width = ui.value;
-				//console.log(ui.value);
-				options.width = width;
-				$(getElementSelector(container, elementIds.msmsplot)).css({width: width});
+	$(getElementSelector(container, elementIds.slider_width)).slider({
+	    value:options.width,
+	    min: 100,
+	    max: 1500,
+	    step: 50,
+	    slide: function(event, ui) {
+		var width = ui.value;
+		//console.log(ui.value);
+		options.width = width;
+		$(getElementSelector(container, elementIds.msmsplot)).css({width: width});
                 $(getElementSelector(container, elementIds.massErrorPlot)).css({width: width});
 
-				plotAccordingToChoices(container);
-				if(options.ms1peaks && options.ms1peaks.length > 0) {
-					$(getElementSelector(container, elementIds.msPlot)).css({width: width});
-					createMs1Plot(container);
-				}
-				$(getElementSelector(container, elementIds.slider_width_val)).text(width);
-				if ( options.sizeChangeCallbackFunction ) {
-					options.sizeChangeCallbackFunction();
-				}
-			}
-		});
-		
-		$(getElementSelector(container, elementIds.slider_height)).slider({
-			value:options.height,
-			min: 100,
-			max: 1000,
-			step: 50,
-			slide: function(event, ui) {
-				var height = ui.value;
-				//console.log(ui.value);
-				options.height = height
-				$(getElementSelector(container, elementIds.msmsplot)).css({height: height});
-				plotAccordingToChoices(container);
-				$(getElementSelector(container, elementIds.slider_height_val)).text(height);
-				if ( options.sizeChangeCallbackFunction ) {
-					options.sizeChangeCallbackFunction();
-				}
-			}
-		});
-	}
-	
-	function printPlot(container) {
+		plotAccordingToChoices(container);
+		if(options.ms1peaks && options.ms1peaks.length > 0) {
+		    $(getElementSelector(container, elementIds.msPlot)).css({width: width});
+		    createMs1Plot(container);
+		}
+		$(getElementSelector(container, elementIds.slider_width_val)).text(width);
+		if ( options.sizeChangeCallbackFunction ) {
+		    options.sizeChangeCallbackFunction();
+		}
+	    }
+	});
 
-		$(getElementSelector(container, elementIds.printLink)).click(function() {
+	$(getElementSelector(container, elementIds.slider_height)).slider({
+	    value:options.height,
+	    min: 100,
+	    max: 1000,
+	    step: 50,
+	    slide: function(event, ui) {
+		var height = ui.value;
+		//console.log(ui.value);
+		options.height = height
+		$(getElementSelector(container, elementIds.msmsplot)).css({height: height});
+		plotAccordingToChoices(container);
+		$(getElementSelector(container, elementIds.slider_height_val)).text(height);
+		if ( options.sizeChangeCallbackFunction ) {
+		    options.sizeChangeCallbackFunction();
+		}
+	    }
+	});
+    }
+
+    function printPlot(container) {
+
+	$(getElementSelector(container, elementIds.printLink)).click(function() {
 
             var parent = container.parent();
 
-			// create another div and move the plots into that div
-			$(document.body).append('<div id="tempPrintDiv"></div>');
-			$("#tempPrintDiv").append(container.detach());
-			$("#tempPrintDiv").siblings().addClass("noprint");
-			
-			var plotOptions = container.data("plotOptions");
+	    // create another div and move the plots into that div
+	    $(document.body).append('<div id="tempPrintDiv"></div>');
+	    $("#tempPrintDiv").append(container.detach());
+	    $("#tempPrintDiv").siblings().addClass("noprint");
 
-			container.find(".bar").addClass('noprint');
-			$(getElementSelector(container, elementIds.optionsTable)).addClass('noprint');
-			$(getElementSelector(container, elementIds.ionTableLoc1)).addClass('noprint');
-			$(getElementSelector(container, elementIds.ionTableLoc2)).addClass('noprint');
-			$(getElementSelector(container, elementIds.viewOptionsDiv)).addClass('noprint');
-			
-			plotOptions.series.peaks.print = true; // draw the labels in the DOM for sharper print output
-			plotAccordingToChoices(container);
-			window.print();
-			
-			
-			// remove the class after printing so that if the user prints 
-			// via the browser's print menu the whole page is printed
-			container.find(".bar").removeClass('noprint');
-			$(getElementSelector(container, elementIds.optionsTable)).removeClass('noprint');
-			$(getElementSelector(container, elementIds.ionTableLoc1)).removeClass('noprint');
-			$(getElementSelector(container, elementIds.ionTableLoc2)).removeClass('noprint');
-			$(getElementSelector(container, elementIds.viewOptionsDiv)).removeClass('noprint');
-			$("#tempPrintDiv").siblings().removeClass("noprint");
-			
+	    var plotOptions = container.data("plotOptions");
+
+	    container.find(".bar").addClass('noprint');
+	    $(getElementSelector(container, elementIds.optionsTable)).addClass('noprint');
+	    $(getElementSelector(container, elementIds.ionTableLoc1)).addClass('noprint');
+	    $(getElementSelector(container, elementIds.ionTableLoc2)).addClass('noprint');
+	    $(getElementSelector(container, elementIds.viewOptionsDiv)).addClass('noprint');
+
+	    plotOptions.series.peaks.print = true; // draw the labels in the DOM for sharper print output
+	    plotAccordingToChoices(container);
+	    window.print();
 
 
-			plotOptions.series.peaks.print = false; // draw the labels in the canvas
-			plotAccordingToChoices(container);
-			
-			// move the plots back to the original location
+	    // remove the class after printing so that if the user prints
+	    // via the browser's print menu the whole page is printed
+	    container.find(".bar").removeClass('noprint');
+	    $(getElementSelector(container, elementIds.optionsTable)).removeClass('noprint');
+	    $(getElementSelector(container, elementIds.ionTableLoc1)).removeClass('noprint');
+	    $(getElementSelector(container, elementIds.ionTableLoc2)).removeClass('noprint');
+	    $(getElementSelector(container, elementIds.viewOptionsDiv)).removeClass('noprint');
+	    $("#tempPrintDiv").siblings().removeClass("noprint");
+
+
+
+	    plotOptions.series.peaks.print = false; // draw the labels in the canvas
+	    plotAccordingToChoices(container);
+
+	    // move the plots back to the original location
             parent.append(container.detach());
-			$("#tempPrintDiv").remove();
-			
-			
-			/*var canvas = plot.getCanvas();
-			var iWidth=3500;
-			var iHeight = 3050;
-			var oSaveCanvas = document.createElement("canvas");
-			oSaveCanvas.width = iWidth;
-			oSaveCanvas.height = iHeight;
-			oSaveCanvas.style.width = iWidth+"px";
-			oSaveCanvas.style.height = iHeight+"px";
-			var oSaveCtx = oSaveCanvas.getContext("2d");
-			oSaveCtx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, iWidth, iHeight);
-			
-			var dataURL = oSaveCanvas.toDataURL("image/png");
-			window.location = dataURL;*/
-			
-			
-		});
-	}
-	
-	// -----------------------------------------------
-	// SELECTED DATASETS
-	// -----------------------------------------------
-	function getDatasets(container) {
+	    $("#tempPrintDiv").remove();
+
+
+	    /*var canvas = plot.getCanvas();
+	      var iWidth=3500;
+	      var iHeight = 3050;
+	      var oSaveCanvas = document.createElement("canvas");
+	      oSaveCanvas.width = iWidth;
+	      oSaveCanvas.height = iHeight;
+	      oSaveCanvas.style.width = iWidth+"px";
+	      oSaveCanvas.style.height = iHeight+"px";
+	      var oSaveCtx = oSaveCanvas.getContext("2d");
+	      oSaveCtx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, iWidth, iHeight);
+
+	      var dataURL = oSaveCanvas.toDataURL("image/png");
+	      window.location = dataURL;*/
+
+	});
+    }
+
+    // -----------------------------------------------
+    // SELECTED DATASETS
+    // -----------------------------------------------
+    function getDatasets(container) {
 
         var options = container.data("options");
 
         // selected ions
-		var selectedIonTypes = getSelectedIonTypes(container);
-		
-		calculateTheoreticalSeries(container, selectedIonTypes);
-		
-		// add the un-annotated peaks
-		var data = [{data: options.peaks, color: "#bbbbbb", labelType: 'none'}];
-		
-		// add the annotated peaks
-		var seriesMatches = getSeriesMatches(container, selectedIonTypes);
-		for(var i = 0; i < seriesMatches.length; i += 1) {
-			data.push(seriesMatches[i]);
-		}
+	var selectedIonTypes = getSelectedIonTypes(container);
+
+	calculateTheoreticalSeries(container, selectedIonTypes);
+
+	// add the un-annotated peaks
+        //added two peak lists into data
+        var peaks1 = {data: options.peaks,  color: "#bbbbbb", labelType: 'none', yaxis:1};
+        var peaks2 = {data: options.peaks2, color: "#bbbbbb", labelType: 'none', yaxis:2, label: options.ms2peaks2Label};
+        var data = [];
+        data.push(peaks1);
+        data.push(peaks2);
+
+
+	// add the annotated peaks
+	var seriesMatches = getSeriesMatches(container, selectedIonTypes);
+	for(var i = 0; i < seriesMatches.length; i += 1) {
+	    data.push(seriesMatches[i]);
+	}
 
         // add immonium ions
         if(labelImmoniumIons(container))
@@ -1113,16 +1163,16 @@
         }
 
         // add user reporter ions
-        if( container.data("userReporterSeries") ) {
+        if(container.data("userReporterSeries")) {
             data.push(container.data("userReporterSeries"));
         }
 
-		// add any user specified extra peaks
-		for(var i = 0; i < options.extraPeakSeries.length; i += 1) {
-			data.push(options.extraPeakSeries[i]);
-		}
-		return data;
+	// add any user specified extra peaks
+	for(var i = 0; i < options.extraPeakSeries.length; i += 1) {
+	    data.push(options.extraPeakSeries[i]);
 	}
+	return data;
+    }
 
     function labelPrecursorPeak(container)
     {
@@ -1167,7 +1217,7 @@
             {
                 immoniumIonMatches.push([match.bestPeak[0], match.bestPeak[1]]);
                 labels.push(ion.aa + '-' + match.bestPeak[0].toFixed(1));
-			    antic += match.bestPeak[1];
+		antic += match.bestPeak[1];
             }
         }
         container.data("anticImmonium", antic);
@@ -1227,7 +1277,7 @@
         var itraqIons = [113.107325, 114.11068, 115.107715, 116.111069, 117.114424, 118.111459, 119.114814, 121.121524];
 
         var tmtWholeLabel = 230.1702;
-        var tmtIons = [126.127726, 127.124761, 127.131081, 128.128116, 128.134436, 129.131471, 129.137790, 130.134825, 130.141145, 131.138180, 131.144499]; // tmt-11
+        var tmtIons = [126.127726, 127.124761, 127.131081, 128.128116, 128.134436, 129.131471, 129.137790, 130.134825, 130.141145, 131.138180, 131.144500, 132.141535, 132.147855, 133.14489, 133.15121, 134.148245]; // tmt-16
 
         var reporterSeries = [];
         reporterSeries.push({color: "#2f4f4f", ions: itraqIons, wholeLabel: itraqWholeLabel});  // DarkSlateBlue
@@ -1270,10 +1320,11 @@
 
         if(matches.length > 0)
         {
-            container.data("userReporterSeries",  {data: matches, labels: labels, color:"#2f4f4f"} ) // DarkSlateBlue
+            container.data("userReporterSeries",  {data: matches, labels: labels, color:"#2f4f4f"} ); // DarkSlateBlue
             container.data("anticUserReporterIons", antic);
         }
     }
+
 
     function calculateReporters(seriesInfo, container)
     {
@@ -1289,7 +1340,7 @@
             if(match.bestPeak)
             {
                 matches.push([match.bestPeak[0], match.bestPeak[1]]);
-			    antic += match.bestPeak[1];
+		antic += match.bestPeak[1];
             }
         }
         var labels = [];
@@ -1312,7 +1363,7 @@
         {
             matches.push([match.bestPeak[0], match.bestPeak[1]]);
             labels.push('nterm');
-		    antic += match.bestPeak[1];
+	    antic += match.bestPeak[1];
         }
 
         container.data("anticReporter", antic);
@@ -1323,161 +1374,161 @@
     }
 
 
-	//-----------------------------------------------
-	// SELECTED ION TYPES
-	// -----------------------------------------------
-	function getSelectedIonTypes(container) {
+    //-----------------------------------------------
+    // SELECTED ION TYPES
+    // -----------------------------------------------
+    function getSelectedIonTypes(container) {
 
-		var ions = [];
-		var charges = [];
-		$(getElementSelector(container, elementIds.ion_choice)).find("input:checked").each(function () {
-	        var key = $(this).attr("id");
-	        var tokens = key.split("_");
-	        ions.push(tokens[0]);
-	        charges.push(tokens[1]);
-	  	});
-	    
-	    var selected = [];
+	var ions = [];
+	var charges = [];
+	$(getElementSelector(container, elementIds.ion_choice)).find("input:checked").each(function () {
+	    var key = $(this).attr("id");
+	    var tokens = key.split("_");
+	    ions.push(tokens[0]);
+	    charges.push(tokens[1]);
+	});
+
+	var selected = [];
         var ion;
         for (var i = 0; i < ions.length; i += 1) {
             selected.push(ion = Ion.get(ions[i], charges[i]));
         }
-	    
-	    return selected;
-	}
-	
-	function getSelectedNtermIons(selectedIonTypes) {
-		var ntermIons = [];
-		
-		for(var i = 0; i < selectedIonTypes.length; i += 1) {
-			var sion = selectedIonTypes[i];
-			if(sion.type == "a" || sion.type == "b" || sion.type == "c") 
-            {
-				ntermIons.push(sion);
-		}
-		}
-		ntermIons.sort(function(m,n) {
-			if(m.type == n.type) {
-				return (m.charge - n.charge);
-			}
-			else {
-				return m.type - n.type;
-			}
-		});
-		return ntermIons;
-	}
 
-	function getSelectedCtermIons(selectedIonTypes) {
-		var ctermIons = [];
-		
-		for(var i = 0; i < selectedIonTypes.length; i += 1) {
-			var sion = selectedIonTypes[i];
-			if(sion.type == "x" || sion.type == "y" || sion.type == "z") 
-				ctermIons.push(sion);
-		}
-		ctermIons.sort(function(m,n) {
-			if(m.type == n.type) {
-				return (m.charge - n.charge);
-			}
-			else {
-				return m.type - n.type;
-			}
-		});
-		return ctermIons;
+	return selected;
+    }
+
+    function getSelectedNtermIons(selectedIonTypes) {
+	var ntermIons = [];
+
+	for(var i = 0; i < selectedIonTypes.length; i += 1) {
+	    var sion = selectedIonTypes[i];
+	    if(sion.type == "a" || sion.type == "b" || sion.type == "c")
+            {
+		ntermIons.push(sion);
+	    }
 	}
-	
-	// ---------------------------------------------------------
-	// CALCULATE THEORETICAL MASSES FOR THE SELECTED ION SERIES
-	// ---------------------------------------------------------
-	function calculateTheoreticalSeries(container, selectedIons) {
+	ntermIons.sort(function(m,n) {
+	    if(m.type == n.type) {
+		return (m.charge - n.charge);
+	    }
+	    else {
+		return m.type - n.type;
+	    }
+	});
+	return ntermIons;
+    }
+
+    function getSelectedCtermIons(selectedIonTypes) {
+	var ctermIons = [];
+
+	for(var i = 0; i < selectedIonTypes.length; i += 1) {
+	    var sion = selectedIonTypes[i];
+	    if(sion.type == "x" || sion.type == "y" || sion.type == "z")
+		ctermIons.push(sion);
+	}
+	ctermIons.sort(function(m,n) {
+	    if(m.type == n.type) {
+		return (m.charge - n.charge);
+	    }
+	    else {
+		return m.type - n.type;
+	    }
+	});
+	return ctermIons;
+    }
+
+    // ---------------------------------------------------------
+    // CALCULATE THEORETICAL MASSES FOR THE SELECTED ION SERIES
+    // ---------------------------------------------------------
+    function calculateTheoreticalSeries(container, selectedIons) {
 
         if(container.data("massTypeChanged"))
         {
             // Clear out the theoretical ion series if the selected mass type changed.
             container.data("ionSeries", {a: [], b: [], c: [], x: [], y: [], z: []});
         }
-		if(selectedIons) {
-		
-			var todoIonSeries = [];
-			var todoIonSeriesData = [];
-            var ionSeries = container.data("ionSeries");
-			for(var i = 0; i < selectedIons.length; i += 1) {
-				var sion = selectedIons[i];
-				if(sion.type == "a") {
-					if(ionSeries.a[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.a[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.a[sion.charge]);
-					}
-				}
-				if(sion.type == "b") {
-					if(ionSeries.b[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.b[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.b[sion.charge]);
-					}
-				}
-				if(sion.type == "c") {
-					if(ionSeries.c[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.c[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.c[sion.charge]);
-					}
-				}
-				if(sion.type == "x") {
-					if(ionSeries.x[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.x[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.x[sion.charge]);
-					}
-				}
-				if(sion.type == "y") {
-					if(ionSeries.y[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.y[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.y[sion.charge]);
-					}
-				}
-				if(sion.type == "z") {
-					if(ionSeries.z[sion.charge])	continue; // already calculated
-					else {
-						todoIonSeries.push(sion);
-						ionSeries.z[sion.charge] = [];
-						todoIonSeriesData.push(ionSeries.z[sion.charge]);
-					}
-				}
-			}
+	if(selectedIons) {
 
-			if(container.data("options").sequence) {
+	    var todoIonSeries = [];
+	    var todoIonSeriesData = [];
+            var ionSeries = container.data("ionSeries");
+	    for(var i = 0; i < selectedIons.length; i += 1) {
+		var sion = selectedIons[i];
+		if(sion.type == "a") {
+		    if(ionSeries.a[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.a[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.a[sion.charge]);
+		    }
+		}
+		if(sion.type == "b") {
+		    if(ionSeries.b[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.b[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.b[sion.charge]);
+		    }
+		}
+		if(sion.type == "c") {
+		    if(ionSeries.c[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.c[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.c[sion.charge]);
+		    }
+		}
+		if(sion.type == "x") {
+		    if(ionSeries.x[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.x[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.x[sion.charge]);
+		    }
+		}
+		if(sion.type == "y") {
+		    if(ionSeries.y[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.y[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.y[sion.charge]);
+		    }
+		}
+		if(sion.type == "z") {
+		    if(ionSeries.z[sion.charge])	continue; // already calculated
+		    else {
+			todoIonSeries.push(sion);
+			ionSeries.z[sion.charge] = [];
+			todoIonSeriesData.push(ionSeries.z[sion.charge]);
+		    }
+		}
+	    }
+
+	    if(container.data("options").sequence) {
 
                 var sequence = container.data("options").sequence
-				var massType = getMassType(container);
-				
-				for(var i = 1; i < sequence.length; i += 1) {
-					
-					for(var j = 0; j < todoIonSeries.length; j += 1) {
-						var tion = todoIonSeries[j];
-						var ionSeriesData = todoIonSeriesData[j];
+		var massType = getMassType(container);
+
+		for(var i = 1; i < sequence.length; i += 1) {
+
+		    for(var j = 0; j < todoIonSeries.length; j += 1) {
+			var tion = todoIonSeries[j];
+			var ionSeriesData = todoIonSeriesData[j];
 
                         var ion = Ion.getSeriesIon(tion, container.data("options").peptide, i, massType);
                         // Put the ion masses in increasing value of m/z, For c-term ions the array will have to be
                         // populated backwards.
-						if(tion.term == "n")
+			if(tion.term == "n")
                             // Add to end of array
-							ionSeriesData.push(ion);
-						else if(tion.term == "c")
+			    ionSeriesData.push(ion);
+			else if(tion.term == "c")
                             // Add to beginning of array
-							ionSeriesData.unshift(ion);
-					}
-				}
-			}
+			    ionSeriesData.unshift(ion);
+		    }
 		}
+	    }
 	}
+    }
 
     function getMassType(container)
     {
@@ -1494,26 +1545,26 @@
         return container.find("input[name='"+getRadioName(container, "peakAssignOpt")+"']:checked").val();
     }
 
-	// -----------------------------------------------
-	// MATCH THEORETICAL MASSES WITH PEAKS IN THE SCAN
-	// -----------------------------------------------
-	function recalculateFragmentMatches(container) {
-	    return (container.data("massErrorChanged") ||
-	    		container.data("massTypeChanged") ||
-	    		container.data("peakAssignmentTypeChanged") ||
-	    		container.data("selectedNeutralLossChanged"));
-	}
+    // -----------------------------------------------
+    // MATCH THEORETICAL MASSES WITH PEAKS IN THE SCAN
+    // -----------------------------------------------
+    function recalculateFragmentMatches(container) {
+	return (container.data("massErrorChanged") ||
+		container.data("massTypeChanged") ||
+		container.data("peakAssignmentTypeChanged") ||
+		container.data("selectedNeutralLossChanged"));
+    }
 
-	function clearIonSeries(container)
+    function clearIonSeries(container)
     {
         container.data("ionSeriesMatch", {a: [], b: [], c: [], x: [], y: [], z: []});
         container.data("ionSeriesLabels", {a: [], b: [], c: [], x: [], y: [], z: []});
         container.data("ionSeriesAntic", {a: [], b: [], c: [], x: [], y: [], z: []});
     }
 
-	function getSeriesMatches(container, selectedIonTypes) {
-		
-		var dataSeries = [];
+    function getSeriesMatches(container, selectedIonTypes) {
+
+	var dataSeries = [];
 
         if(recalculateFragmentMatches(container))
         {
@@ -1522,8 +1573,8 @@
             clearIonSeries(container);
         }
 
-		var peakAssignmentType = getPeakAssignmentType(container);
-		var peakLabelType = container.find("input[name='"+getRadioName(container, "peakLabelOpt")+"']:checked").val();
+	var peakAssignmentType = getPeakAssignmentType(container);
+	var peakLabelType = container.find("input[name='"+getRadioName(container, "peakLabelOpt")+"']:checked").val();
         var massType = getMassType(container);
         var massErrorUnit = getMassErrorUnit(container);
 
@@ -1536,91 +1587,90 @@
 
 
 
-		for(var j = 0; j < selectedIonTypes.length; j += 1) {
-		
-			var ion = selectedIonTypes[j];
+	for(var j = 0; j < selectedIonTypes.length; j += 1) {
 
-			
-			if(ion.type == "a") {
-				if(!ionSeriesMatch.a[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var adata = calculateMatchingPeaks(container, ionSeries.a[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(adata && adata.length > 0) {
-						ionSeriesMatch.a[ion.charge] = adata[0];
-						ionSeriesLabels.a[ion.charge] = adata[1];
-						ionSeriesAntic.a[ion.charge] = adata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.a[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.a[ion.charge]});
-			}
-			
-			if(ion.type == "b") {
-				if(!ionSeriesMatch.b[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var bdata = calculateMatchingPeaks(container, ionSeries.b[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(bdata && bdata.length > 0) {
-						ionSeriesMatch.b[ion.charge] = bdata[0];
-						ionSeriesLabels.b[ion.charge] = bdata[1];
-                        ionSeriesAntic.b[ion.charge] = bdata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.b[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.b[ion.charge]});
-			}
-			
-			if(ion.type == "c") {
-				if(!ionSeriesMatch.c[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var cdata = calculateMatchingPeaks(container, ionSeries.c[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(cdata && cdata.length > 0) {
-						ionSeriesMatch.c[ion.charge] = cdata[0];
-						ionSeriesLabels.c[ion.charge] = cdata[1];
-                        ionSeriesAntic.c[ion.charge] = cdata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.c[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.c[ion.charge]});
-			}
-			
-			if(ion.type == "x") {
-				if(!ionSeriesMatch.x[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var xdata = calculateMatchingPeaks(container, ionSeries.x[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(xdata && xdata.length > 0) {
-						ionSeriesMatch.x[ion.charge] = xdata[0];
-						ionSeriesLabels.x[ion.charge] = xdata[1];
-                        ionSeriesAntic.x[ion.charge] = xdata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.x[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.x[ion.charge]});
-			}
-			
-			if(ion.type == "y") {
-				if(!ionSeriesMatch.y[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var ydata = calculateMatchingPeaks(container, ionSeries.y[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(ydata && ydata.length > 0) {
-						ionSeriesMatch.y[ion.charge] = ydata[0];
-						ionSeriesLabels.y[ion.charge] = ydata[1];
-                        ionSeriesAntic.y[ion.charge] = ydata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.y[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.y[ion.charge]});
-			}
-			
-			if(ion.type == "z") {
-				if(!ionSeriesMatch.z[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
-					// calculated matching peaks
-					var zdata = calculateMatchingPeaks(container, ionSeries.z[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
-					if(zdata && zdata.length > 0) {
-						ionSeriesMatch.z[ion.charge] = zdata[0];
-						ionSeriesLabels.z[ion.charge] = zdata[1];
-                        ionSeriesAntic.z[ion.charge] = zdata[2];
-					}
-				}
-				dataSeries.push({data: ionSeriesMatch.z[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.z[ion.charge]});
-			}
+	    var ion = selectedIonTypes[j];
+
+	    if(ion.type == "a") {
+		if(!ionSeriesMatch.a[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var adata = calculateMatchingPeaks(container, ionSeries.a[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(adata && adata.length > 0) {
+			ionSeriesMatch.a[ion.charge] = adata[0];
+			ionSeriesLabels.a[ion.charge] = adata[1];
+			ionSeriesAntic.a[ion.charge] = adata[2];
+		    }
 		}
-		return dataSeries;
+		dataSeries.push({data: ionSeriesMatch.a[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.a[ion.charge]});
+	    }
+
+	    if(ion.type == "b") {
+		if(!ionSeriesMatch.b[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var bdata = calculateMatchingPeaks(container, ionSeries.b[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(bdata && bdata.length > 0) {
+			ionSeriesMatch.b[ion.charge] = bdata[0];
+			ionSeriesLabels.b[ion.charge] = bdata[1];
+                        ionSeriesAntic.b[ion.charge] = bdata[2];
+		    }
+		}
+		dataSeries.push({data: ionSeriesMatch.b[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.b[ion.charge]});
+	    }
+
+	    if(ion.type == "c") {
+		if(!ionSeriesMatch.c[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var cdata = calculateMatchingPeaks(container, ionSeries.c[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(cdata && cdata.length > 0) {
+			ionSeriesMatch.c[ion.charge] = cdata[0];
+			ionSeriesLabels.c[ion.charge] = cdata[1];
+                        ionSeriesAntic.c[ion.charge] = cdata[2];
+		    }
+		}
+		dataSeries.push({data: ionSeriesMatch.c[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.c[ion.charge]});
+	    }
+
+	    if(ion.type == "x") {
+		if(!ionSeriesMatch.x[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var xdata = calculateMatchingPeaks(container, ionSeries.x[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(xdata && xdata.length > 0) {
+			ionSeriesMatch.x[ion.charge] = xdata[0];
+			ionSeriesLabels.x[ion.charge] = xdata[1];
+                        ionSeriesAntic.x[ion.charge] = xdata[2];
+		    }
+		}
+		dataSeries.push({data: ionSeriesMatch.x[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.x[ion.charge]});
+	    }
+
+	    if(ion.type == "y") {
+		if(!ionSeriesMatch.y[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var ydata = calculateMatchingPeaks(container, ionSeries.y[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(ydata && ydata.length > 0) {
+			ionSeriesMatch.y[ion.charge] = ydata[0];
+			ionSeriesLabels.y[ion.charge] = ydata[1];
+                        ionSeriesAntic.y[ion.charge] = ydata[2];
+		    }
+		}
+		dataSeries.push({data: ionSeriesMatch.y[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.y[ion.charge]});
+	    }
+
+	    if(ion.type == "z") {
+		if(!ionSeriesMatch.z[ion.charge]) { // re-calculate only if matching peaks for this series have not been calculated already
+		    // calculated matching peaks
+		    var zdata = calculateMatchingPeaks(container, ionSeries.z[ion.charge], peaks, massError, massErrorUnit, peakAssignmentType, massType);
+		    if(zdata && zdata.length > 0) {
+			ionSeriesMatch.z[ion.charge] = zdata[0];
+			ionSeriesLabels.z[ion.charge] = zdata[1];
+                        ionSeriesAntic.z[ion.charge] = zdata[2];
+		    }
+		}
+		dataSeries.push({data: ionSeriesMatch.z[ion.charge], color: ion.color, labelType: peakLabelType, labels: ionSeriesLabels.z[ion.charge]});
+	    }
 	}
+	return dataSeries;
+    }
 
     function getNeutralLosses(container) {
         var neutralLosses = [];
@@ -1650,26 +1700,26 @@
         return ionmz;
     }
 
-	function calculateMatchingPeaks(container, ionSeries, allPeaks, massTolerance, massErrorUnit, peakAssignmentType, massType) {
+    function calculateMatchingPeaks(container, ionSeries, allPeaks, massTolerance, massErrorUnit, peakAssignmentType, massType) {
 
         // console.log("calculating matching peaks");
-		var peakIndex = 0;
-		
-		var matchData = [];
-		matchData[0] = []; // peaks
-		matchData[1] = []; // labels -- ions;
-        matchData[2] = 0;  // Annotated ion current for this series.
-	    var peptide = container.data("options").peptide;
+	var peakIndex = 0;
 
-		for(var i = 0; i < ionSeries.length; i += 1) {
-			
-			var sion = ionSeries[i];
-			
-			// get match for water and / or ammonia loss.
+	var matchData = [];
+	matchData[0] = []; // peaks
+	matchData[1] = []; // labels -- ions;
+        matchData[2] = 0;  // Annotated ion current for this series.
+	var peptide = container.data("options").peptide;
+
+	for(var i = 0; i < ionSeries.length; i += 1) {
+
+	    var sion = ionSeries[i];
+
+	    // get match for water and / or ammonia loss.
             var minIndex = Number.MAX_VALUE;
             var neutralLossOptions = peptide.getPotentialLosses(sion);
 
-	        var index = getMatchForIon(sion, matchData, allPeaks, peakIndex, massTolerance, massErrorUnit, peakAssignmentType, null, massType);
+	    var index = getMatchForIon(sion, matchData, allPeaks, peakIndex, massTolerance, massErrorUnit, peakAssignmentType, null, massType);
             minIndex = Math.min(minIndex, index);
 
             for(var n = 1; n < neutralLossOptions.length; n += 1)
@@ -1678,30 +1728,30 @@
                 for(var k = 0; k < loss_options_with_n_losses.lossCombinationCount(); k += 1)
                 {
                     var lossCombination = loss_options_with_n_losses.getLossCombination(k);
-			        var index = getMatchForIon(sion, matchData, allPeaks, peakIndex, massTolerance, massErrorUnit, peakAssignmentType, lossCombination, massType);
+		    var index = getMatchForIon(sion, matchData, allPeaks, peakIndex, massTolerance, massErrorUnit, peakAssignmentType, lossCombination, massType);
                     minIndex = Math.min(minIndex, index);
                 }
             }
 
             peakIndex = minIndex;
-		}
-		
-		return matchData;
 	}
-	
-	// sion -- theoretical ion
-	// matchData -- array to which we will add a peak if there is a match
-	// allPeaks -- array with all the scan peaks
-	// peakIndex -- current index in peaks array
-	// Returns the index of the matching peak, if one is found
+
+	return matchData;
+    }
+
+    // sion -- theoretical ion
+    // matchData -- array to which we will add a peak if there is a match
+    // allPeaks -- array with all the scan peaks
+    // peakIndex -- current index in peaks array
+    // Returns the index of the matching peak, if one is found
     function getMatchForIon(sion, matchData, allPeaks, peakIndex, massTolerance, massErrorUnit, peakAssignmentType, neutralLosses, massType) {
-		
-		if(!neutralLosses)
-			sion.match = false; // reset;
-		var ionmz = ionMz(sion, neutralLosses, massType);
+
+	if(!neutralLosses)
+	    sion.match = false; // reset;
+	var ionmz = ionMz(sion, neutralLosses, massType);
         var peakLabel = getLabel(sion, neutralLosses);
 
-		var __ret = getMatchingPeak(peakIndex, allPeaks, ionmz, massTolerance, massErrorUnit, peakAssignmentType);
+	var __ret = getMatchingPeak(peakIndex, allPeaks, ionmz, massTolerance, massErrorUnit, peakAssignmentType);
 
         peakIndex = __ret.peakIndex;
         var bestPeak = __ret.bestPeak;
@@ -1717,8 +1767,8 @@
             }
         }
 
-		return peakIndex;
-	}
+	return peakIndex;
+    }
 
     function getMatchingPeakForMz(container, allPeaks, ionMz)
     {
@@ -1786,7 +1836,6 @@
         return {peakIndex:peakIndex, bestPeak:bestPeak, theoreticalMz:ionmz};
     }
 
-	
 
     function getPeaks(container)
     {
@@ -1824,7 +1873,7 @@
         var window = 50.0;
         for(var i = 0; i < peaks.length; i += 1) {
 
-			var peak = peaks[i];
+	    var peak = peaks[i];
 
             var intensity = peak[1];
 
@@ -1874,11 +1923,11 @@
             }
 
             var mean = totalIntensity / peakCount;
-            if(peakCount <= 2 && intensity >= maxIntensity * 0.8)
-            {
-                sparsePeaks.push(peak);
-            }
-            else if(peakCount <= 10 && intensity == maxIntensity)
+	    if(peakCount <= 2 && intensity >= maxIntensity * 0.8)
+	    {
+		sparsePeaks.push(peak);
+	    }
+	    else if(peakCount <= 10 && intensity == maxIntensity)
             {
                 sparsePeaks.push(peak);
             }
@@ -1899,15 +1948,15 @@
                 }
                 // console.log(intensity+"  "+mean+"  "+sdev);
             }
-		}
+	}
         // console.log("Sparse Peak count: "+sparsePeaks.length);
         // console.log("All Peaks count: "+peaks.length);
         container.data("options").sparsePeaks = sparsePeaks;
     }
 
-	// -----------------------------------------------
-	// INITIALIZE THE CONTAINER
-	// -----------------------------------------------
+    // -----------------------------------------------
+    // INITIALIZE THE CONTAINER
+    // -----------------------------------------------
     function createContainer(div) {
 
         div.append('<div id="'+elementIds.lorikeet_content+"_"+index+'"></div>');
@@ -1916,26 +1965,26 @@
         return container;
     }
 
-	function initContainer(container) {
+    function initContainer(container) {
 
         var options = container.data("options");
 
         var rowspan = 2;
 
-		var parentTable = '<table cellpadding="0" cellspacing="5" class="lorikeet-outer-table"> ';
-		parentTable += '<tbody> ';
-		parentTable += '<tr> ';
+	var parentTable = '<table cellpadding="0" cellspacing="5" class="lorikeet-outer-table"> ';
+	parentTable += '<tbody> ';
+	parentTable += '<tr> ';
 
-		// Header
-		parentTable += '<td colspan="3" class="bar"> ';
-		parentTable += '</div> ';
-		parentTable += '</td> ';
-		parentTable += '</tr> ';
+	// Header
+	parentTable += '<td colspan="3" class="bar"> ';
+	parentTable += '</div> ';
+	parentTable += '</td> ';
+	parentTable += '</tr> ';
 
-		// options table
-		parentTable += '<tr> ';
-		parentTable += '<td rowspan="'+rowspan+'" valign="top" id="'+getElementId(container, elementIds.optionsTable)+'"> ';
-		parentTable += '</td> ';
+	// options table
+	parentTable += '<tr> ';
+	parentTable += '<td rowspan="'+rowspan+'" valign="top" id="'+getElementId(container, elementIds.optionsTable)+'"> ';
+	parentTable += '</td> ';
 
         if(options.showSequenceInfo) {
             // placeholder for sequence, m/z, scan number etc
@@ -1964,268 +2013,273 @@
         }
 
 
-		// placeholders for the ms/ms plot
-		parentTable += '<tr> ';
-		parentTable += '<td style="background-color: white; padding:5px; border:1px dotted #cccccc;" valign="top" align="center"> ';
-		parentTable += '<div id="'+getElementId(container, elementIds.msmsplot)+'" align="bottom" style="width:'+options.width+'px;height:'+options.height+'px;"></div> ';
+	// placeholders for the ms/ms plot
+	parentTable += '<tr> ';
+	parentTable += '<td style="background-color: white; padding:5px; border:1px dotted #cccccc;" valign="top" align="center"> ';
+	parentTable += '<div id="'+getElementId(container, elementIds.msmsplot)+'" align="bottom" style="width:'+options.width+'px;height:'+options.height+'px;"></div> ';
 
-		// placeholder for viewing options (zoom, plot size etc.)
-		parentTable += '<div id="'+getElementId(container, elementIds.viewOptionsDiv)+'" align="top" style="margin-top:15px;"></div> ';
+	// placeholder for viewing options (zoom, plot size etc.)
+	parentTable += '<div id="'+getElementId(container, elementIds.viewOptionsDiv)+'" align="top" style="margin-top:15px;"></div> ';
 
         // placeholder for peak mass error plot
         parentTable += '<div id="'+getElementId(container, elementIds.massErrorPlot)+'" style="width:'+options.width+'px;height:100px;"></div> ';
 
-		// placeholder for ms1 plot (if data is available)
-		if(options.ms1peaks && options.ms1peaks.length > 0) {
-			parentTable += '<div id="'+getElementId(container, elementIds.msPlot)+'" style="width:'+options.width+'px;height:100px;"></div> ';
-		}
-		parentTable += '</td> ';
-		parentTable += '</tr> ';
-
-
-		// Footer & placeholder for moving ion table
-		parentTable += '<tr> ';
-		parentTable += '<td colspan="3" class="bar noprint" valign="top" align="center" id="'+getElementId(container, elementIds.ionTableLoc2)+'" > ';
-		parentTable += '<div align="center" style="width:100%;font-size:10pt;"> ';
-		parentTable += '</div> ';
-		parentTable += '</td> ';
-		parentTable += '</tr> ';
-
-		parentTable += '</tbody> ';
-		parentTable += '</table> ';
-
-		container.append(parentTable);
-		
-		return container;
+	// placeholder for ms1 plot (if data is available)
+	if(options.ms1peaks && options.ms1peaks.length > 0) {
+	    parentTable += '<div id="'+getElementId(container, elementIds.msPlot)+'" style="width:'+options.width+'px;height:100px;"></div> ';
 	}
-	
-	
-	//---------------------------------------------------------
-	// ION TABLE
-	//---------------------------------------------------------
-	function makeIonTable(container) {
+	parentTable += '</td> ';
+	parentTable += '</tr> ';
+
+
+	// Footer & placeholder for moving ion table
+	parentTable += '<tr> ';
+	parentTable += '<td colspan="3" class="bar noprint" valign="top" align="center" id="'+getElementId(container, elementIds.ionTableLoc2)+'" > ';
+	parentTable += '<div align="center" style="width:100%;font-size:10pt;"> ';
+	parentTable += '</div> ';
+	parentTable += '</td> ';
+	parentTable += '</tr> ';
+
+	parentTable += '</tbody> ';
+	parentTable += '</table> ';
+
+	container.append(parentTable);
+
+	return container;
+    }
+
+
+    //---------------------------------------------------------
+    // ION TABLE
+    //---------------------------------------------------------
+    function makeIonTable(container) {
 
         var options = container.data("options");
 
-	 	// selected ions
-		var selectedIonTypes = getSelectedIonTypes(container);
-		var ntermIons = getSelectedNtermIons(selectedIonTypes);
-		var ctermIons = getSelectedCtermIons(selectedIonTypes);
-		
-		var myTable = '' ;
-		myTable += '<table id="'+getElementId(container, elementIds.ionTable)+'" cellpadding="2" class="font_small '+elementIds.ionTable+'">';
-		myTable +=  "<thead>";
-		myTable +=   "<tr>";
+	// selected ions
+	var selectedIonTypes = getSelectedIonTypes(container);
+	var ntermIons = getSelectedNtermIons(selectedIonTypes);
+	var ctermIons = getSelectedCtermIons(selectedIonTypes);
 
-		// nterm ions
-		for(var i = 0; i < ntermIons.length; i += 1) {
-			myTable +=    "<th>" +ntermIons[i].label+  "</th>";   
-		}
-		myTable +=    "<th>" +"#"+  "</th>"; 
-		myTable +=    "<th>" +"Seq"+  "</th>"; 
-		myTable +=    "<th>" +"#"+  "</th>"; 
-		// cterm ions
-		for(var i = 0; i < ctermIons.length; i += 1) {
-			myTable +=    "<th>" +ctermIons[i].label+  "</th>"; 
-		}
-		myTable +=   "</tr>";
-		myTable +=  "</thead>";
-		
-		myTable +=  "<tbody>";
+	var myTable = '' ;
+	myTable += '<table id="'+getElementId(container, elementIds.ionTable)+'" cellpadding="2" class="font_small '+elementIds.ionTable+'">';
+	myTable +=  "<thead>";
+	myTable +=   "<tr>";
+
+	// nterm ions
+	for(var i = 0; i < ntermIons.length; i += 1) {
+	    myTable +=    "<th>" +ntermIons[i].label+  "</th>";
+	}
+	myTable +=    "<th>" +"#"+  "</th>";
+	myTable +=    "<th>" +"Seq"+  "</th>";
+	myTable +=    "<th>" +"#"+  "</th>";
+	// cterm ions
+	for(var i = 0; i < ctermIons.length; i += 1) {
+	    myTable +=    "<th>" +ctermIons[i].label+  "</th>";
+	}
+	myTable +=   "</tr>";
+	myTable +=  "</thead>";
+
+	myTable +=  "<tbody>";
 
         var ionSeries = container.data("ionSeries");
 
-		for(var i = 0; i < options.sequence.length; i += 1) {
+	for(var i = 0; i < options.sequence.length; i += 1) {
             var aaChar = options.sequence.charAt(i);
-			myTable +=   "<tr>";
+	    myTable +=   "<tr>";
 
-			// nterm ions
-			for(var n = 0; n < ntermIons.length; n += 1) {
-				if(i < options.sequence.length - 1) {
-					var seriesData = getCalculatedSeries(ionSeries, ntermIons[n]);
-					var cls = "";
-					var style = "";
-					if(seriesData[i].match) {
-						cls="matchIon";
-						style="style='background-color:"+Ion.getSeriesColor(ntermIons[n])+";'";
-					}
-					myTable +=    "<td class='"+cls+"' "+style+" >" +round(seriesData[i].mz)+  "</td>";  
-				}
-				else {
-					myTable +=    "<td>" +"&nbsp;"+  "</td>"; 
-				} 
-			}
-			
-			myTable += "<td class='numCell'>"+(i+1)+"</td>";
-			if(options.peptide.varMods()[i+1])
-				myTable += "<td class='seq modified'>"+aaChar+"</td>";
-			else
-				myTable += "<td class='seq'>"+aaChar+"</td>";
-			myTable += "<td class='numCell'>"+(options.sequence.length - i)+"</td>";
-			
-			// cterm ions
-			for(var c = 0; c < ctermIons.length; c += 1) {
-				if(i > 0) {
-					var seriesData = getCalculatedSeries(ionSeries, ctermIons[c]);
-					var idx = options.sequence.length - i - 1;
-					var cls = "";
-					var style = "";
-					if(seriesData[idx].match) {
-						cls="matchIon";
-						style="style='background-color:"+Ion.getSeriesColor(ctermIons[c])+";'";
-					}
-					myTable +=    "<td class='"+cls+"' "+style+" >" +round(seriesData[idx].mz)+  "</td>";  
-				}
-				else {
-					myTable +=    "<td>" +"&nbsp;"+  "</td>"; 
-				} 
-			}
-			
+	    // nterm ions
+	    for(var n = 0; n < ntermIons.length; n += 1) {
+		if(i < options.sequence.length - 1) {
+		    var seriesData = getCalculatedSeries(ionSeries, ntermIons[n]);
+		    var cls = "";
+		    var style = "";
+		    if(seriesData[i].match) {
+			cls="matchIon";
+			style="style='background-color:"+Ion.getSeriesColor(ntermIons[n])+";'";
+		    }
+		    else if(seriesData[i].mz < options.peaks[0][0] |
+			    seriesData[i].mz > options.peaks[options.peaks.length - 1][0]) {
+			cls="numCell";
+		    }
+		    myTable +=    "<td class='"+cls+"' "+style+" >" +round(seriesData[i].mz)+  "</td>";
 		}
-		myTable +=   "</tr>";
-		
-		myTable += "</tbody>";
-		myTable += "</table>";
-		
-		// alert(myTable);
-		$(getElementSelector(container, elementIds.ionTable)).remove();
-		$(getElementSelector(container, elementIds.ionTableDiv)).prepend(myTable); // add as the first child
-		
-		if ( options.sizeChangeCallbackFunction ) {
-			options.sizeChangeCallbackFunction();
+		else {
+		    myTable +=    "<td>" +"&nbsp;"+  "</td>";
 		}
+	    }
+
+	    myTable += "<td class='numCell'>"+(i+1)+"</td>";
+	    if(options.peptide.varMods()[i+1])
+		myTable += "<td class='seq modified'>"+aaChar+"</td>";
+	    else
+		myTable += "<td class='seq'>"+aaChar+"</td>";
+	    myTable += "<td class='numCell'>"+(options.sequence.length - i)+"</td>";
+
+	    // cterm ions
+	    for(var c = 0; c < ctermIons.length; c += 1) {
+		if(i > 0) {
+		    var seriesData = getCalculatedSeries(ionSeries, ctermIons[c]);
+		    var idx = options.sequence.length - i - 1;
+		    var cls = "";
+		    var style = "";
+		    if(seriesData[idx].match) {
+			cls="matchIon";
+			style="style='background-color:"+Ion.getSeriesColor(ctermIons[c])+";'";
+		    }
+                    else if(seriesData[idx].mz < options.peaks[0][0] |
+                            seriesData[idx].mz > options.peaks[options.peaks.length - 1][0]) {
+			cls="numCell";
+                    }
+		    myTable +=    "<td class='"+cls+"' "+style+" >" +round(seriesData[idx].mz)+  "</td>";
+		}
+		else {
+		    myTable +=    "<td>" +"&nbsp;"+  "</td>";
+		}
+	    }
+
+	}
+	myTable +=   "</tr>";
+
+	myTable += "</tbody>";
+	myTable += "</table>";
+
+	// alert(myTable);
+	$(getElementSelector(container, elementIds.ionTable)).remove();
+	$(getElementSelector(container, elementIds.ionTableDiv)).prepend(myTable); // add as the first child
+
+	if ( options.sizeChangeCallbackFunction ) {
+	    options.sizeChangeCallbackFunction();
+	}
 
         showAnticInfo(container); // Total annotated ion current
-	}
-	
-	function getCalculatedSeries(ionSeries, ion) {
+    }
+
+    function getCalculatedSeries(ionSeries, ion) {
         if(ion.type == "a")
-			return ionSeries.a[ion.charge];
-		if(ion.type == "b")
-			return ionSeries.b[ion.charge];
-		if(ion.type == "c")
-			return ionSeries.c[ion.charge];
-		if(ion.type == "x")
-			return ionSeries.x[ion.charge];
-		if(ion.type == "y")
-			return ionSeries.y[ion.charge];
-		if(ion.type == "z")
-			return ionSeries.z[ion.charge];
-	}
-	
-	function makeIonTableMovable(container, options) {
+	    return ionSeries.a[ion.charge];
+	if(ion.type == "b")
+	    return ionSeries.b[ion.charge];
+	if(ion.type == "c")
+	    return ionSeries.c[ion.charge];
+	if(ion.type == "x")
+	    return ionSeries.x[ion.charge];
+	if(ion.type == "y")
+	    return ionSeries.y[ion.charge];
+	if(ion.type == "z")
+	    return ionSeries.z[ion.charge];
+    }
 
-		$(getElementSelector(container, elementIds.moveIonTable)).hover(
-			function(){
-		         $(this).css({cursor:'pointer'}); //mouseover
-		    }
-		);
+    function makeIonTableMovable(container, options) {
 
-		$(getElementSelector(container, elementIds.moveIonTable)).click(function() {
-			var ionTableDiv = $(getElementSelector(container, elementIds.ionTableDiv));
-			if(ionTableDiv.is(".moved")) {
-				ionTableDiv.removeClass("moved");
-				ionTableDiv.detach();
-				$(getElementSelector(container, elementIds.ionTableLoc1)).append(ionTableDiv);
-			}
-			else {
-				ionTableDiv.addClass("moved");
-				ionTableDiv.detach();
-				$(getElementSelector(container, elementIds.ionTableLoc2)).append(ionTableDiv);
-			}
-			
-			if ( options.sizeChangeCallbackFunction ) {
-				options.sizeChangeCallbackFunction();
-			}
-		});
-	}
+	$(getElementSelector(container, elementIds.moveIonTable)).hover(
+	    function(){
+		$(this).css({cursor:'pointer'}); //mouseover
+	    }
+	);
 
-	//---------------------------------------------------------
-	// SEQUENCE INFO
-	//---------------------------------------------------------
-	function showSequenceInfo (container) {
+	$(getElementSelector(container, elementIds.moveIonTable)).click(function() {
+	    var ionTableDiv = $(getElementSelector(container, elementIds.ionTableDiv));
+	    if(ionTableDiv.is(".moved")) {
+		ionTableDiv.removeClass("moved");
+		ionTableDiv.detach();
+		$(getElementSelector(container, elementIds.ionTableLoc1)).append(ionTableDiv);
+	    }
+	    else {
+		ionTableDiv.addClass("moved");
+		ionTableDiv.detach();
+		$(getElementSelector(container, elementIds.ionTableLoc2)).append(ionTableDiv);
+	    }
+
+	    if ( options.sizeChangeCallbackFunction ) {
+		options.sizeChangeCallbackFunction();
+	    }
+	});
+    }
+
+    //---------------------------------------------------------
+    // SEQUENCE INFO
+    //---------------------------------------------------------
+    function showSequenceInfo (container) {
 
         var options = container.data("options");
 
-		var specinfo = '';
-		if(options.sequence) {
-			
-			specinfo += '<div>';
-			specinfo += '<span style="font-weight:bold; color:#8B0000;">'+getModifiedSequence(options)+'</span>';
+	var specinfo = '';
+	if(options.sequence) {
 
-			var neutralMass = 0;
-			
-			if(options.precursorMassType == 'mono')
-			    neutralMass = options.peptide.getNeutralMassMono();
+	    specinfo += '<div>';
+	    specinfo += '<span style="font-weight:bold; color:#8B0000;">'+getModifiedSequence(options)+'</span>';
+
+	    var neutralMass = 0;
+
+	    if(options.precursorMassType == 'mono')
+		neutralMass = options.peptide.getNeutralMassMono();
             else
                 neutralMass = options.peptide.getNeutralMassAvg();
-				
-			// console.log(options.precursorMassType + " " + neutralMass);
-			var mz;
-			if(options.charge) {
-				mz = Ion.getMz(neutralMass, options.charge);
-			}
+
+	    // console.log(options.precursorMassType + " " + neutralMass);
+	    var mz;
+	    if(options.charge) {
+		mz = Ion.getMz(neutralMass, options.charge);
+	    }
 
             // save the theoretical m/z in the options
             options.theoreticalMz = mz;
-			
-			var mass = neutralMass + Ion.MASS_PROTON;
-			specinfo += ', MH+ '+mass.toFixed(4);
-			if(mz) 
-				specinfo += ', m/z '+mz.toFixed(4);
-			specinfo += '</div>';
-			
-		}
-		
-		// first clear the div if it has anything
-		$(getElementSelector(container, elementIds.seqinfo)).empty();
-		$(getElementSelector(container, elementIds.seqinfo)).append(specinfo);
-	}
-	
-	function getModifiedSequence(options) {
-		
-		var modSeq = '';
-		for(var i = 0; i < options.sequence.length; i += 1) {
-			
-			if(options.peptide.varMods()[i+1])
-				modSeq += '<span style="background-color:yellow;padding:1px;border:1px dotted #CFCFCF;">'+options.sequence.charAt(i)+"</span>";
-			else
-				modSeq += options.sequence.charAt(i);
-		}
-		
-		return modSeq;
-	}
-	
-	//---------------------------------------------------------
-	// FILE INFO -- filename, scan number, precursor m/z and charge
-	//---------------------------------------------------------
-	function showFileInfo (container) {
 
+	    var mass = neutralMass + Ion.MASS_PROTON;
+	    specinfo += ', MH+ '+mass.toFixed(4);
+	    if(mz)
+		specinfo += ', m/z '+mz.toFixed(4);
+	    specinfo += '</div>';
+
+	}
+
+	// first clear the div if it has anything
+	$(getElementSelector(container, elementIds.seqinfo)).empty();
+	$(getElementSelector(container, elementIds.seqinfo)).append(specinfo);
+    }
+
+    function getModifiedSequence(options) {
+	var modSeq = '';
+	for(var i = 0; i < options.sequence.length; i += 1) {
+
+	    if(options.peptide.varMods()[i+1])
+		modSeq += '<span style="background-color:yellow;padding:1px;border:1px dotted #CFCFCF;">'+options.sequence.charAt(i)+"</span>";
+	    else
+		modSeq += options.sequence.charAt(i);
+	}
+	return modSeq;
+    }
+
+    //---------------------------------------------------------
+    // FILE INFO -- filename, scan number, precursor m/z and charge
+    //---------------------------------------------------------
+    function showFileInfo (container) {
         var options = container.data("options");
 
-		var fileinfo = '';
-			
-		if(options.fileName || options.scanNum) {
-			fileinfo += '<div style="margin-top:5px;" class="font_small">';
-			if(options.fileName) {
-				fileinfo += 'File: '+options.fileName;
-			}
-			if(options.scanNum) {
-				fileinfo += ', Scan: '+options.scanNum;
-			}
-         if(options.precursorMz) {
-            fileinfo += ', Exp. m/z: '+options.precursorMz;
-         }
-			if(options.charge) {
-				fileinfo += ', Charge: '+options.charge;
-			}
-			fileinfo += '</div>';
-		}
-		
-		$(getElementSelector(container, elementIds.fileinfo)).append(fileinfo);
+	var fileinfo = '';
+
+	if(options.fileName || options.scanNum) {
+	    fileinfo += '<div style="margin-top:5px;" class="font_small">';
+	    if(options.fileName) {
+		fileinfo += 'File: '+options.fileName;
+	    }
+	    if(options.scanNum) {
+		fileinfo += ', Scan: '+options.scanNum;
+	    }
+            if(options.precursorMz) {
+		fileinfo += ', Exp. m/z: '+options.precursorMz;
+            }
+	    if(options.charge) {
+		fileinfo += ', Charge: '+options.charge;
+	    }
+	    fileinfo += '</div>';
 	}
-	
-	//---------------------------------------------------------
+
+	$(getElementSelector(container, elementIds.fileinfo)).append(fileinfo);
+    }
+
+    //---------------------------------------------------------
     // USER-SPECIFIED REPORTER ION INFO
     //---------------------------------------------------------
     function showUserReporterIonsInfo (container) {
@@ -2248,55 +2302,55 @@
     }
 
     //---------------------------------------------------------
-	// MODIFICATION INFO
-	//---------------------------------------------------------
-	function showModInfo (container) {
+    // MODIFICATION INFO
+    //---------------------------------------------------------
+    function showModInfo (container) {
 
         var options = container.data("options");
 
-		var modInfo = '';
-			
-		modInfo += '<div>';
-		if(options.ntermMod || options.ntermMod > 0) {
-			modInfo += 'Add to N-term: <b>'+round(options.ntermMod)+'</b>';
-		}
-		if(options.ctermMod || options.ctermMod > 0) {
-			modInfo += 'Add to C-term: <b>'+round(options.ctermMod)+'</b>';
-		}
-		modInfo += '</div>';
-		
-		if(options.staticMods && options.staticMods.length > 0) {
-			var sm_modInfo = '<div style="margin-top:5px;">';
-			sm_modInfo += 'Static Modifications: ';
+	var modInfo = '';
+
+	modInfo += '<div>';
+	if(options.ntermMod || options.ntermMod > 0) {
+	    modInfo += 'Add to N-term: <b>'+round(options.ntermMod)+'</b>';
+	}
+	if(options.ctermMod || options.ctermMod > 0) {
+	    modInfo += 'Add to C-term: <b>'+round(options.ctermMod)+'</b>';
+	}
+	modInfo += '</div>';
+
+	if(options.staticMods && options.staticMods.length > 0) {
+	    var sm_modInfo = '<div style="margin-top:5px;">';
+	    sm_modInfo += 'Static Modifications: ';
             var count = 0;
-			for(var i = 0; i < options.staticMods.length; i += 1) {
-				var mod = options.staticMods[i];
+	    for(var i = 0; i < options.staticMods.length; i += 1) {
+		var mod = options.staticMods[i];
                 if(mod.modMass == 0.0)
                     continue;
-				//if(i > 0) modInfo += ', ';
-				sm_modInfo += "<div><b>"+mod.aa.code+": "+mod.modMass+"</b></div>";
+		//if(i > 0) modInfo += ', ';
+		sm_modInfo += "<div><b>"+mod.aa.code+": "+mod.modMass+"</b></div>";
                 count += 1;
-			}
-			sm_modInfo += '</div>';
+	    }
+	    sm_modInfo += '</div>';
             if(count > 0)
             {
                 modInfo += sm_modInfo;
             }
-		}
-		
-		if(options.variableMods && options.variableMods.length > 0) {
-			
-			var uniqVarMods = {};
-			for(var i = 0; i < options.variableMods.length; i += 1) {
-				var mod = options.variableMods[i];
+	}
+
+	if(options.variableMods && options.variableMods.length > 0) {
+
+	    var uniqVarMods = {};
+	    for(var i = 0; i < options.variableMods.length; i += 1) {
+		var mod = options.variableMods[i];
                 var varmods = uniqVarMods[mod.aa.code + ' ' + mod.modMass];
-				if(!varmods)
+		if(!varmods)
                 {
-					varmods = [];
+		    varmods = [];
                     uniqVarMods[mod.aa.code + ' ' + mod.modMass] = varmods;
                 }
-				varmods.push(mod);
-			}  
+		varmods.push(mod);
+	    }
 
             var keys = [];
             for(var key in uniqVarMods)
@@ -2308,11 +2362,11 @@
             }
             keys.sort();
 
-			modInfo += '<div style="margin-top:5px;">';
-			modInfo += 'Variable Modifications: ';
+	    modInfo += '<div style="margin-top:5px;">';
+	    modInfo += 'Variable Modifications: ';
             modInfo += "<table class='varModsTable'>";
-			for(var k = 0; k < keys.length; k++) {
-				var varmods = uniqVarMods[keys[k]];
+	    for(var k = 0; k < keys.length; k++) {
+		var varmods = uniqVarMods[keys[k]];
                 modInfo += "<tr><td><span style='font-weight: bold;'>";
                 modInfo += varmods[0].aa.code+": "+varmods[0].modMass;
                 modInfo += "</span></td>";
@@ -2325,15 +2379,15 @@
                 }
                 modInfo += "]</td>";
                 modInfo += "</tr>";
-			}
+	    }
             modInfo += "</table>";
-			modInfo += '</div>';
-		}
-		
-		$(getElementSelector(container, elementIds.modInfo)).append(modInfo);
+	    modInfo += '</div>';
 	}
-	
-	//---------------------------------------------------------
+
+	$(getElementSelector(container, elementIds.modInfo)).append(modInfo);
+    }
+
+    //---------------------------------------------------------
     // ANTIC INFO
     //---------------------------------------------------------
     function showAnticInfo (container) {
@@ -2361,96 +2415,98 @@
             antic += container.data("anticUserReporterIons");
         }
 
-	    var anticInfo = '<div id="'+getElementId(container, elementIds.anticInfo)+'" style="margin-top:5px;">';
-	    anticInfo += 'Annotated Ion Current: ';
-	    anticInfo += "<div><b>"+round(antic)+"</b></div>";
-	    anticInfo += '</div>';
+	var percent = 100*round(antic / container.data("totalIonCurrent"));
 
-	    $(getElementSelector(container, elementIds.anticInfo)).replaceWith(anticInfo);
+	var anticInfo = '<div id="'+getElementId(container, elementIds.anticInfo)+'" style="margin-top:5px;">';
+	anticInfo += 'Annotated Ion Current: ';
+	anticInfo += "<div><b>"+round(antic)+"</b> ("+percent+"%)</div>";
+	anticInfo += '</div>';
+
+	$(getElementSelector(container, elementIds.anticInfo)).replaceWith(anticInfo);
     }
     //---------------------------------------------------------
-	// VIEWING OPTIONS TABLE
-	//---------------------------------------------------------
-	function makeViewingOptions(container) {
+    // VIEWING OPTIONS TABLE
+    //---------------------------------------------------------
+    function makeViewingOptions(container) {
 
         var options = container.data("options");
 
-		var myContent = '';
-		
-		// reset zoom option
-		myContent += '<nobr> ';
-		myContent += '<span style="width:100%; font-size:8pt; margin-top:5px; color:sienna;">Click and drag in the plot to zoom</span> ';
-		myContent += 'X:<input id="'+getElementId(container, elementIds.zoom_x)+'" type="checkbox" value="X" checked="checked"/> ';
-		myContent += '&nbsp;Y:<input id="'+getElementId(container, elementIds.zoom_y)+'" type="checkbox" value="Y" /> ';
-		myContent += '&nbsp;<input id="'+getElementId(container, elementIds.resetZoom)+'" type="button" value="Zoom Out" /> ';
-		myContent += '&nbsp;<input id="'+getElementId(container, elementIds.printLink)+'" type="button" value="Print" /> ';
-		myContent += '</nobr> ';
-		
-		myContent += '&nbsp;&nbsp;';
-		
-		// tooltip option
-		myContent += '<nobr> ';
-		myContent += '<input id="'+getElementId(container, elementIds.enableTooltip)+'" type="checkbox">Enable tooltip ';
-		myContent += '</nobr> ';
+	var myContent = '';
+
+	// reset zoom option
+	myContent += '<nobr> ';
+	myContent += '<span style="width:100%; font-size:8pt; margin-top:5px; color:sienna;">Click and drag in the plot to zoom</span> ';
+	myContent += 'X:<input id="'+getElementId(container, elementIds.zoom_x)+'" type="checkbox" value="X" checked="checked"/> ';
+	myContent += '&nbsp;Y:<input id="'+getElementId(container, elementIds.zoom_y)+'" type="checkbox" value="Y" /> ';
+	myContent += '&nbsp;<input id="'+getElementId(container, elementIds.resetZoom)+'" type="button" value="Zoom Out" /> ';
+	myContent += '&nbsp;<input id="'+getElementId(container, elementIds.printLink)+'" type="button" value="Print" /> ';
+	myContent += '</nobr> ';
+
+	myContent += '&nbsp;&nbsp;';
+
+	// tooltip option
+	myContent += '<nobr> ';
+	myContent += '<label><input id="'+getElementId(container, elementIds.enableTooltip)+'" type="checkbox">Enable tooltip </label>';
+	myContent += '</nobr> ';
 
         // mass error plot option
         myContent += '<nobr>';
-        myContent += '<input id="'+getElementId(container, elementIds.massErrorPlot_option)+'" type="checkbox" ';
+        myContent += '<label><input id="'+getElementId(container, elementIds.massErrorPlot_option)+'" type="checkbox" ';
         if(options.showMassErrorPlot === true)
         {
             myContent += ' checked="checked"';
         }
-        myContent += '>Plot mass error ';
+        myContent += '>Plot mass error </label>';
         myContent += '</nobr>';
-		
-		myContent += '<br>';
-		
-		$(getElementSelector(container, elementIds.viewOptionsDiv)).append(myContent);
-		if(!options.showViewingOptions) {
+
+	myContent += '<br>';
+
+	$(getElementSelector(container, elementIds.viewOptionsDiv)).append(myContent);
+	if(!options.showViewingOptions) {
             $(getElementSelector(container, elementIds.viewOptionsDiv)).hide();
         }
-	}
-	
-	
-	//---------------------------------------------------------
-	// OPTIONS TABLE
-	//---------------------------------------------------------
-	function makeOptionsTable(container, defaultChargeStates, defaultSelectedIons) {
+    }
+
+
+    //---------------------------------------------------------
+    // OPTIONS TABLE
+    //---------------------------------------------------------
+    function makeOptionsTable(container, defaultChargeStates, defaultSelectedIons) {
 
         var options = container.data("options");
 
-		var myTable = '';
-		myTable += '<table cellpadding="2" cellspacing="2"> ';
-		myTable += '<tbody> ';
-		
-		// Ions
-		myTable += '<tr><td class="optionCell"> ';
-		
-		myTable += '<b>Ions:</b> ';
-		myTable += '<div id="'+getElementId(container, elementIds.ion_choice)+'" style="margin-bottom: 10px"> ';
-		myTable += '<!-- a ions --> ';
+	var myTable = '';
+	myTable += '<table cellpadding="2" cellspacing="2"> ';
+	myTable += '<tbody> ';
+
+	// Ions
+	myTable += '<tr><td class="optionCell"> ';
+
+	myTable += '<b>Ions:</b> ';
+	myTable += '<div id="'+getElementId(container, elementIds.ion_choice)+'" style="margin-bottom: 10px"> ';
+	myTable += '<!-- a ions --> ';
         myTable += addIonToOptionsTable('a', defaultChargeStates, defaultSelectedIons['a']);
-		myTable += '<br/> ';
-		myTable += '<!-- b ions --> ';
+	myTable += '<br/> ';
+	myTable += '<!-- b ions --> ';
         myTable += addIonToOptionsTable('b', defaultChargeStates, defaultSelectedIons['b']);
-		myTable += '<br/> ';
-		myTable += '<!-- c ions --> ';
+	myTable += '<br/> ';
+	myTable += '<!-- c ions --> ';
         myTable += addIonToOptionsTable('c', defaultChargeStates, defaultSelectedIons['c']);
-		myTable += '<br/> ';
-		myTable += '<!-- x ions --> ';
+	myTable += '<br/> ';
+	myTable += '<!-- x ions --> ';
         myTable += addIonToOptionsTable('x', defaultChargeStates, defaultSelectedIons['x']);
-		myTable += '<br/> ';
-		myTable += '<!-- y ions --> ';
+	myTable += '<br/> ';
+	myTable += '<!-- y ions --> ';
         myTable += addIonToOptionsTable('y', defaultChargeStates, defaultSelectedIons['y']);
-		myTable += '<br/> ';
-		myTable += '<!-- z ions --> ';
+	myTable += '<br/> ';
+	myTable += '<!-- z ions --> ';
         myTable += addIonToOptionsTable('z', defaultChargeStates, defaultSelectedIons['z']);
-		myTable += '<br/> ';
-		myTable += '<span id="'+getElementId(container, elementIds.deselectIonsLink)+'" style="font-size:8pt;text-decoration: underline; color:sienna;cursor:pointer;">[Deselect All]</span> ';
-		myTable += '</div> ';
-		
-		myTable += '<span style="font-weight: bold;">Neutral Loss:</span> ';
-		myTable += '<div id="'+getElementId(container, elementIds.nl_choice)+'"> ';
+	myTable += '<br/> ';
+	myTable += '<span id="'+getElementId(container, elementIds.deselectIonsLink)+'" style="font-size:8pt;text-decoration: underline; color:sienna;cursor:pointer;">[Deselect All]</span> ';
+	myTable += '</div> ';
+
+	myTable += '<span style="font-weight: bold;">Neutral Loss:</span> ';
+	myTable += '<div id="'+getElementId(container, elementIds.nl_choice)+'"> ';
         var peptide = container.data("options").peptide;
         var idx = 0;
         for (lossKey in peptide.lorikeetPotentialLosses)
@@ -2459,9 +2515,9 @@
             if(!loss)
                 continue;
             if(idx++ != 0)myTable += '<br> ';
-            myTable += '<nobr> <input type="checkbox" value="'+loss.label()+'" id="'+loss.label()+'"/> ';
+            myTable += '<nobr><label> <input type="checkbox" value="'+loss.label()+'" id="'+loss.label()+'"/> ';
             myTable += loss.htmlLabel();
-            myTable += '</nobr> ';
+            myTable += '</label></nobr> ';
         }
         for(var lossKey in peptide.customPotentialLosses)
         {
@@ -2469,117 +2525,117 @@
             if(!loss)
                 continue;
             if(idx++ != 0)myTable += '<br> ';
-            myTable += '<nobr> <input type="checkbox" value="'+loss.label()+'" id="'+loss.label()+ '" checked = "checked"/> ';
+            myTable += '<nobr><label> <input type="checkbox" value="'+loss.label()+'" id="'+loss.label()+ '" checked = "checked"/> ';
             myTable += loss.htmlLabel();
-            myTable += '</nobr> ';
+            myTable += '</label></nobr> ';
         }
-		myTable += '</div> ';
+	myTable += '</div> ';
 
         // Immonium ions
-        myTable+= '<input type="checkbox" value="true" ';
+        myTable+= '<label><input type="checkbox" value="true" ';
         if(options.labelImmoniumIons == true)
         {
             myTable+=' checked="checked"';
         }
-        myTable+= ' id="'+getElementId(container, elementIds.immoniumIons)+'"/><span style="font-weight:bold;">Immonium ions</span>';
+        myTable+= ' id="'+getElementId(container, elementIds.immoniumIons)+'"/><span style="font-weight:bold;">Immonium ions</span></label>';
 
         // Reporter ions
         myTable += "<br/>";
-        myTable+= '<input type="checkbox" value="true" ';
+        myTable+= '<label><input type="checkbox" value="true" ';
         if(options.labelReporters == true)
         {
             myTable+=' checked="checked"';
         }
-        myTable+= ' id="'+getElementId(container, elementIds.reporterIons)+'"/><span style="font-weight:bold;">Reporter ions</span>';
+        myTable+= ' id="'+getElementId(container, elementIds.reporterIons)+'"/><span style="font-weight:bold;">Reporter ions</span></label>';
 
         // Unfragmented precursor ions
         myTable += "<br/>";
-	    myTable+= '<input type="checkbox" value="true" ';
+	myTable+= '<label><input type="checkbox" value="true" ';
         if(options.labelPrecursorPeak === true)
-	    {
-		    myTable+=' checked="checked"';
-	    }
-        myTable+= ' id="'+getElementId(container, elementIds.labelPrecursor)+'"/><span style="font-weight:bold;">Precursor ions</span>';
+	{
+	    myTable+=' checked="checked"';
+	}
+        myTable+= ' id="'+getElementId(container, elementIds.labelPrecursor)+'"/><span style="font-weight:bold;">Precursor ions</span></label>';
 
-		myTable += '</td> </tr> ';
-		
-		// mass type
-		myTable += '<tr><td class="optionCell"> ';
-		myTable += '<div> Frag. Mass Type:<br/> ';
-		myTable += '<nobr> ';
-		myTable += '<input type="radio" name="'+getRadioName(container, "massTypeOpt")+'" value="mono"';
+	myTable += '</td> </tr> ';
+
+	// mass type
+	myTable += '<tr><td class="optionCell"> ';
+	myTable += '<div> Frag. Mass Type:<br/> ';
+	myTable += '<nobr> ';
+	myTable += '<label><input type="radio" name="'+getRadioName(container, "massTypeOpt")+'" value="mono"';
         if(options.fragmentMassType == 'mono')
             myTable += ' checked = "checked" ';
-        myTable += '/><span style="font-weight: bold;">Mono</span> ';
-		myTable += '<input type="radio" name="'+getRadioName(container, "massTypeOpt")+'" value="avg"';
+        myTable += '/><span style="font-weight: bold;">Mono</span></label> ';
+	myTable += '<label><input type="radio" name="'+getRadioName(container, "massTypeOpt")+'" value="avg"';
         if(options.fragmentMassType == 'avg')
             myTable += ' checked = "checked" ';
-        myTable += '/><span style="font-weight: bold;">Avg</span> ';
-		myTable += '</nobr> ';
-		myTable += '</div> ';
+        myTable += '/><span style="font-weight: bold;">Avg</span></label> ';
+	myTable += '</nobr> ';
+	myTable += '</div> ';
         // mass tolerance
-		myTable += '<div style="margin-top:10px;"> ';
-		myTable += '<nobr>';
+	myTable += '<div style="margin-top:10px;"> ';
+	myTable += '<nobr>';
         myTable += 'Mass Tol: <input id="'+getElementId(container, elementIds.massError)+'" type="text" value="'+options.massError+'" style="width:3em;"/>';
-		myTable += '</nobr>';
+	myTable += '</nobr>';
         myTable += '<br>';
-        myTable += '<input type="radio" name="'+getRadioName(container, "massErrorUnit")+'" value="' + massErrorTypeTh + '"';
+        myTable += '<label><input type="radio" name="'+getRadioName(container, "massErrorUnit")+'" value="' + massErrorTypeTh + '"';
         if(options.massErrorUnit === massErrorTypeTh)
         {
             myTable += ' checked = "checked" ';
         }
-        myTable += '/><span style="font-weight: bold;">' + massErrorTypeTh + '</span> ';
-        myTable += '<input type="radio" name="'+getRadioName(container, "massErrorUnit")+'" value="' + massErrorTypePpm + '"';
+        myTable += '/><span style="font-weight: bold;">' + massErrorTypeTh + '</span></label> ';
+        myTable += '<label><input type="radio" name="'+getRadioName(container, "massErrorUnit")+'" value="' + massErrorTypePpm + '"';
         if(options.massErrorUnit === massErrorTypePpm)
         {
             myTable += ' checked = "checked" ';
         }
-        myTable += '/><span style="font-weight: bold;">' + massErrorTypePpm + '</span> ';
+        myTable += '/><span style="font-weight: bold;">' + massErrorTypePpm + '</span></label> ';
         myTable += '</div> ';
-		myTable += '<div style="margin-top:10px;" align="center"> ';
-		myTable += '<input id="'+getElementId(container, elementIds.update)+'" type="button" value="Update"/> ';
-		myTable += '</div> ';
-		myTable += '</td> </tr> ';
-		
-		// peak assignment method
-		myTable += '<tr><td class="optionCell"> ';
-		myTable+= '<div> Peak Assignment:<br/> ';
-		myTable+= '<input type="radio" name="'+getRadioName(container, "peakAssignOpt")+'" value="intense" checked="checked"/><span style="font-weight: bold;">Most Intense</span><br/> ';
-		myTable+= '<input type="radio" name="'+getRadioName(container, "peakAssignOpt")+'" value="close"/><span style="font-weight: bold;">Nearest Match</span><br/> ';
-        myTable+= '<input type="checkbox" value="true" ';
+	myTable += '<div style="margin-top:10px;" align="center"> ';
+	myTable += '<input id="'+getElementId(container, elementIds.update)+'" type="button" value="Update"/> ';
+	myTable += '</div> ';
+	myTable += '</td> </tr> ';
+
+	// peak assignment method
+	myTable += '<tr><td class="optionCell"> ';
+	myTable+= '<div> Peak Assignment:<br/> ';
+	myTable+= '<label><input type="radio" name="'+getRadioName(container, "peakAssignOpt")+'" value="intense" checked="checked"/><span style="font-weight: bold;">Most Intense</span></label><br/> ';
+	myTable+= '<label><input type="radio" name="'+getRadioName(container, "peakAssignOpt")+'" value="close"/><span style="font-weight: bold;">Nearest Match</span></label><br/> ';
+        myTable+= '<label><input type="checkbox" value="true" ';
         if(options.peakDetect == true)
         {
             myTable+=' checked="checked"';
         }
-        myTable+= ' id="'+getElementId(container, elementIds.peakDetect)+'"/><span style="font-weight:bold;">Peak Detect</span>';
-		myTable+= '</div> ';
-		myTable += '</td> </tr> ';
-		
-		// peak labels
-		myTable += '<tr><td class="optionCell"> ';
-		myTable+= '<div> Peak Labels:<br/> ';
-		myTable+= '<input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="ion" checked="checked"/><span style="font-weight: bold;">Ion</span>';
-		myTable+= '<input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="mz"/><span style="font-weight: bold;">m/z</span><br/>';
-		myTable+= '<input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="none"/><span style="font-weight: bold;">None</span> ';
-		myTable+= '</div> ';
-		myTable += '</td> </tr> ';
-		
-		// sliders to change plot size
-		myTable += '<tr><td class="optionCell"> ';
-		myTable += '<div>Width: <span id="'+getElementId(container, elementIds.slider_width_val)+'">'+options.width+'</span></div> ';
-		myTable += '<div id="'+getElementId(container, elementIds.slider_width)+'" style="margin-bottom:15px;"></div> ';
-		myTable += '<div>Height: <span id="' + getElementId(container, elementIds.slider_height_val) + '">' + options.height + '</span></div> ';
-		myTable += '<div id="'+getElementId(container, elementIds.slider_height)+'"></div> ';
-		myTable += '</td> </tr> ';
+        myTable+= ' id="'+getElementId(container, elementIds.peakDetect)+'"/><span style="font-weight:bold;">Peak Detect</span></label>';
+	myTable+= '</div> ';
+	myTable += '</td> </tr> ';
 
-		myTable += '</tbody>';
-		myTable += '</table>';
+	// peak labels
+	myTable += '<tr><td class="optionCell"> ';
+	myTable+= '<div> Peak Labels:<br/> ';
+	myTable+= '<label><input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="ion" checked="checked"/><span style="font-weight: bold;">Ion</span></label>';
+	myTable+= '<label><input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="mz"/><span style="font-weight: bold;">m/z</span></label><br/>';
+	myTable+= '<label><input type="radio" name="'+getRadioName(container, "peakLabelOpt")+'" value="none"/><span style="font-weight: bold;">None</span></label> ';
+	myTable+= '</div> ';
+	myTable += '</td> </tr> ';
 
-		$(getElementSelector(container, elementIds.optionsTable)).append(myTable);
+	// sliders to change plot size
+	myTable += '<tr><td class="optionCell"> ';
+	myTable += '<div>Width: <span id="'+getElementId(container, elementIds.slider_width_val)+'">'+options.width+'</span></div> ';
+	myTable += '<div id="'+getElementId(container, elementIds.slider_width)+'" style="margin-bottom:15px;"></div> ';
+	myTable += '<div>Height: <span id="' + getElementId(container, elementIds.slider_height_val) + '">' + options.height + '</span></div> ';
+	myTable += '<div id="'+getElementId(container, elementIds.slider_height)+'"></div> ';
+	myTable += '</td> </tr> ';
+
+	myTable += '</tbody>';
+	myTable += '</table>';
+
+	$(getElementSelector(container, elementIds.optionsTable)).append(myTable);
         if(!options.showOptionsTable) {
             $(getElementSelector(container, elementIds.optionsTable)).hide();
         }
-	}
+    }
 
     function addIonToOptionsTable(ionLabel, charges, selected)
     {
@@ -2596,6 +2652,6 @@
         ionRow += '</nobr> ';
         return ionRow;
     }
-	
-	
+
+
 })(jQuery);


### PR DESCRIPTION
- Basic support for 2-spectrum "butterfly" display
-- The code only triggers if one passes a "peaks2" parameter (otherwise it's business as usual)
-- Set ms2peaks2Label to place a label the 2nd spectrum
-- Matched ions and other labels are not supported for 2nd spectrum, and y-zoom does not work (yet)
-- This is code from collaborators ( https://github.com/baimingze/Lorikeet/commits/master ) with a couple of minor changes

- Updated masses for TMT-16 reporter ions

- Added the <label> tag around most checkbox and radio elements
-- Allows the user to click anywhere on the text associated with the control to change its state.

- Calculate and show % matched/annotated of total ion current

- Set light gray background to cells in ion table that fall outside of m/z range in data

- Unix line endings

- Fixed minor scattered typos